### PR TITLE
More examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,6 @@ before_script:
   - sdl2-config --static-libs
 
 test_script:
+  - cargo clippy -- -D warnings
   - cargo build
   - cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,9 @@ before_script:
   - sdl2-config --cflags
   - sdl2-config --libs
   - sdl2-config --static-libs
+  - rustup component add clippy
 
-test_script:
+script:
   - cargo clippy -- -D warnings
   - cargo build
   - cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,13 @@ edition = "2018"
 license = "Zlib"
 
 [dependencies]
-fermium = "0.0.12"
+fermium = "0.0.13"
 phantom-fields = "^0.1.2"
 libc = "0.2"
 
 [dev-dependencies]
 gl = "0.12"
+glium = "0.25"
 
 [package.metadata.docs.rs]
 features = ["fermium/use_bindgen_lib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ fermium = "0.0.12"
 phantom-fields = "^0.1.2"
 libc = "0.2"
 
+[dev-dependencies]
+gl = "0.12"
+
 [package.metadata.docs.rs]
 features = ["fermium/use_bindgen_lib"]
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,15 @@ An opinionated set of "high level" wrappers for the
 I attempt to make things as safe as is _reasonable_, without actually doing
 anything that would hurt the API design.
 
+There are [examples](/examples/) available if you want a sample of what things
+look like in practice.
+
 ## Building
 
 Obviously this uses SDL2. You need version 2.0.9 or later:
 
 * On Windows the necessary files are provided automatically, and you don't need
-  to do any special setup at all.
+  to do _any_ special setup at all.
 * On non-Windows you need to have installed SDL2 yourself ahead of time:
   * You'll need the `-fPIC` flag enabled in your SDL2 install! This is necessary
     because the build will static link to SDL2 by default.
@@ -28,11 +31,15 @@ Obviously this uses SDL2. You need version 2.0.9 or later:
   * On Linux you can use the [installer script](install-sdl2.sh) in this repo.
     Either run it as is with `sudo` for a default install (to `/usr/local/lib`)
     or adjust it to fit your needs. Linux programmer are all pros, right?
+  * If you attempt to build the lib and it fails because SDL2 isn't installed
+    you'll have to run `cargo clean` to make the `build.rs` work.
 
-`fermium` does a static binding by default, so once you build your program it
-won't depend on SDL2 files any longer.
+The `fermium` bindings do a static compilation by default, so once you build
+your program it won't need to be shipped with any extra files.
 
-Also, somewhat related, you'll probably want to set the
+### Window Subsystem
+
+You'll probably want to set the
 [window_subsystem](https://doc.rust-lang.org/reference/attributes.html#crate-only-attributes)
 to "windows" in your beryllium programs. Just add this to the top of the main
 file of any binary or example:
@@ -45,6 +52,8 @@ Note that we only want it enabled when `debug_assertions` are not active. If
 it's configured you don't have a default console _at all_ so you can't print
 debug messages. We only need to set it with the version we plan to ship to
 users.
+
+This line won't have any effect on the build outside Windows, so no worries.
 
 ## License
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,5 +17,7 @@ install:
 build: false
 
 test_script:
+  - cargo clippy -- -D warnings
   - cargo build
   - cargo test
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -y --default-toolchain %channel% --default-host %target%
+  - rustup component add clippy
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
   - rustc -vV
   - cargo -vV

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,8 @@ environment:
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -y --default-toolchain %channel% --default-host %target%
-  - rustup component add clippy
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+  - rustup component add clippy
   - rustc -vV
   - cargo -vV
 

--- a/examples/audio_queue_tone.rs
+++ b/examples/audio_queue_tone.rs
@@ -9,6 +9,11 @@ fn main() -> Result<(), String> {
   const TWO_PI: f32 = core::f32::consts::PI * 2.0;
   const ONE_HZ_OF_SOUND: f32 = TWO_PI / FREQUENCY as f32;
 
+  // We give the API an audio queue request, and we tell it to _not_ change
+  // anything in the device we get back. What this means is that if the hardware
+  // cannot accommodate our request in some way, SDL2 will act as a middle man
+  // and silently convert between the format we want and the closest match that
+  // the sound card actually supports.
   let audio = sdl.open_default_audio_queue(DefaultAudioQueueRequest {
     frequency: FREQUENCY,
     format: AudioFormat::S16SYS,
@@ -18,6 +23,13 @@ fn main() -> Result<(), String> {
     allow_format_change: false,
     allow_channels_change: false,
   })?;
+  // Alternately, if your code is able to adapt, you can allow a change and
+  // you'll still get the closest possible match, but perhaps not exactly what
+  // you wanted. You'd want to do this if you think that you're better able to
+  // cope with any format conversion considerations than SDL2 is (eg, if you've
+  // written a high quality synth program that can target any sample format, you
+  // might as well target the sound card's native format and avoid an extra
+  // conversion).
 
   // We'll play for 3 seconds.
   let out_sample_count = FREQUENCY as usize * 3;
@@ -43,6 +55,7 @@ fn main() -> Result<(), String> {
   };
   audio.queue_audio(byte_slice)?;
   audio.set_paused(false);
+  // We just sleep while that sound plays out
   std::thread::sleep(std::time::Duration::from_secs(3));
   Ok(())
 }

--- a/examples/audio_queue_tone.rs
+++ b/examples/audio_queue_tone.rs
@@ -22,9 +22,11 @@ fn main() -> Result<(), String> {
   // We'll play for 3 seconds.
   let out_sample_count = FREQUENCY as usize * 3;
   let mut v: Vec<i16> = Vec::with_capacity(out_sample_count);
-  let mut angle: f32 = 0.0;
-  // this gives us a "Middle C" sound, http://pages.mtu.edu/~suits/notefreqs.html
+
+  // We fill the buffer with a basic "middle C" sound wave. Frequency taken from
+  // http://pages.mtu.edu/~suits/notefreqs.html
   let angle_per_sample = 261.63 * ONE_HZ_OF_SOUND;
+  let mut angle: f32 = 0.0;
   for _ in 0..out_sample_count {
     v.push((angle.sin() * 3000.0) as i16);
     angle += angle_per_sample;
@@ -35,7 +37,7 @@ fn main() -> Result<(), String> {
 
   let byte_slice: &[u8] = unsafe {
     core::slice::from_raw_parts(
-      v.as_ptr() as *const _,
+      v.as_ptr() as *const u8,
       v.len() * core::mem::size_of::<i16>(),
     )
   };

--- a/examples/audio_queue_tone.rs
+++ b/examples/audio_queue_tone.rs
@@ -47,6 +47,9 @@ fn main() -> Result<(), String> {
     }
   }
 
+  // Regardless of the actual sample data format, you always convert your sample
+  // buffer into a &[u8] and just throw the bytes into the queue. It's a C API
+  // after all, they have a flexible concept of how types work.
   let byte_slice: &[u8] = unsafe {
     core::slice::from_raw_parts(
       v.as_ptr() as *const u8,

--- a/examples/blank_window.rs
+++ b/examples/blank_window.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+#![allow(clippy::single_match)]
 
 //! This is an "Opening a window" demo.
 

--- a/examples/extern_crate_gl.rs
+++ b/examples/extern_crate_gl.rs
@@ -1,0 +1,53 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+//! Demo of how to setup a blank window using the `gl` crate for OpenGL.
+
+use beryllium::*;
+use gl;
+
+fn main() -> Result<(), String> {
+  // init SDL2
+  let sdl = unsafe { beryllium::init() }?;
+
+  // Set our context request settings
+  sdl.gl_set_attribute(GLattr::ContextProfileMask, CONTEXT_PROFILE_CORE);
+  sdl.gl_set_attribute(GLattr::ContextMajorVersion, 3);
+  sdl.gl_set_attribute(GLattr::ContextMinorVersion, 3);
+
+  // make a window and then a context (which is automatically made current)
+  let window = sdl.create_window(
+    "Extern Crate: `gl`",                                      // title
+    WINDOW_POSITION_CENTERED,                                  // x
+    WINDOW_POSITION_CENTERED,                                  // y
+    800,                                                       // width
+    600,                                                       // height
+    WindowFlags::default().with_shown(true).with_opengl(true), // flags
+  )?;
+  let _ctx = unsafe { window.gl_create_context()? };
+
+  // ONCE WE HAVE A CONTEXT we can load up OpenGL (not before!)
+  gl::load_with(|s| unsafe { sdl.gl_get_proc_address(s) });
+
+  unsafe { gl::ClearColor(1.0, 0.5, 0.0, 1.0) };
+
+  'game_loop: loop {
+    while let Some(event) = sdl.poll_event() {
+      match event {
+        Event::Quit { timestamp } => {
+          println!("Quitting the program after {} milliseconds.", timestamp);
+          break 'game_loop;
+        }
+        _ => (),
+      }
+    }
+
+    // Here is where all your fancy OpenGL drawing can go. In this demo we just
+    // clear the screen over and over.
+    unsafe {
+      gl::Clear(gl::COLOR_BUFFER_BIT);
+      window.gl_swap_window();
+    };
+  }
+
+  Ok(())
+}

--- a/examples/extern_crate_gl.rs
+++ b/examples/extern_crate_gl.rs
@@ -19,7 +19,8 @@ fn main() -> Result<(), String> {
     WindowFlags::default().with_shown(true).with_opengl(true), // flags
   )?;
 
-  // Set our context request settings and make a context
+  // Set our context request settings and make a context (which is automatically
+  // made current for you).
   sdl.gl_set_attribute(GLattr::ContextProfileMask, CONTEXT_PROFILE_CORE);
   sdl.gl_set_attribute(GLattr::ContextMajorVersion, 3);
   sdl.gl_set_attribute(GLattr::ContextMinorVersion, 3);

--- a/examples/extern_crate_glium.rs
+++ b/examples/extern_crate_glium.rs
@@ -4,6 +4,9 @@
 //!
 //! Note that we have to implement quite a bit of glue code to make the two libs
 //! interact.
+//!
+//! MANY THANKS TO [nukep](https://github.com/nukep)! I used their `glium-sdl2`
+//! crate as a guide to figure out how to make a custom backend for `glium`.
 
 use beryllium::*;
 use glium;

--- a/examples/extern_crate_glium.rs
+++ b/examples/extern_crate_glium.rs
@@ -1,37 +1,40 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-//! Demo of how to setup a blank window using the `gl` crate for OpenGL.
+//! Demo of how to setup a blank window using the `glium` crate for OpenGL.
+//!
+//! Note that we have to implement quite a bit of glue code to make the two libs
+//! interact.
 
 use beryllium::*;
 use glium;
 
-use core::convert::TryFrom;
-use core::ops::Deref;
+use core::{ffi::c_void, marker::PhantomData};
+use glium::{
+  backend::{Backend, Context, Facade},
+  debug::DebugCallbackBehavior,
+  Frame, Surface, SwapBuffersError,
+};
+use std::rc::Rc;
 
 fn main() -> Result<(), String> {
-  // init SDL2
+  // Init SDL2
   let sdl = unsafe { beryllium::init() }?;
 
-  // Set our context request settings
-  sdl.gl_set_attribute(GLattr::ContextProfileMask, CONTEXT_PROFILE_CORE);
-  sdl.gl_set_attribute(GLattr::ContextMajorVersion, 3);
-  sdl.gl_set_attribute(GLattr::ContextMinorVersion, 3);
-
-  // make a window and then a context (which is automatically made current)
+  // Make a window (include the flag for OpenGL support!)
   let window = sdl.create_window(
-    "Extern Crate: `gl`",                                      // title
+    "Extern Crate: `glium`",                                   // title
     WINDOW_POSITION_CENTERED,                                  // x
     WINDOW_POSITION_CENTERED,                                  // y
     800,                                                       // width
     600,                                                       // height
     WindowFlags::default().with_shown(true).with_opengl(true), // flags
   )?;
-  let _ctx = unsafe { window.gl_create_context()? };
 
-  // ONCE WE HAVE A CONTEXT we can load up OpenGL (not before!)
-  gl::load_with(|s| unsafe { sdl.gl_get_proc_address(s) });
+  sdl.gl_set_attribute(GLattr::ContextProfileMask, CONTEXT_PROFILE_CORE);
+  sdl.gl_set_attribute(GLattr::ContextMajorVersion, 3);
+  sdl.gl_set_attribute(GLattr::ContextMinorVersion, 3);
 
-  unsafe { gl::ClearColor(1.0, 0.5, 0.0, 1.0) };
+  let facade = BerylliumFacade::from_window(window, &sdl)?;
 
   'game_loop: loop {
     while let Some(event) = sdl.poll_event() {
@@ -44,27 +47,151 @@ fn main() -> Result<(), String> {
       }
     }
 
-    // Here is where all your fancy OpenGL drawing can go. In this demo we just
-    // clear the screen over and over.
-    unsafe {
-      gl::Clear(gl::COLOR_BUFFER_BIT);
-      window.gl_swap_window();
-    };
+    let mut frame = facade.draw();
+    frame.clear_color(1.0, 0.5, 0.0, 1.0);
+    frame.finish().map_err(|e| e.to_string())?;
   }
 
   Ok(())
 }
 
-pub struct GliumWindow<'sdl>(Window<'sdl>);
-impl<'sdl> Deref for GliumWindow<'sdl> {
-  type Target = Window<'sdl>;
-  fn deref(&self) -> &Self::Target {
-    &self.0
+// HERE BEGINS ALL THE LINK UP CODE TO CONNECT GLIUM AND BERYLLIUM
+
+/// This holds the backend parts that beryllium gives you.
+///
+/// We keep them in their raw form and keep a phantom link to the SDLToken
+/// because it makes the whole lifetime thing a lot easier to deal with.
+pub struct BerylliumBackend<'sdl> {
+  win_ptr: *mut fermium::SDL_Window,
+  ctx: fermium::SDL_GLContext,
+  _marker: PhantomData<&'sdl SDLToken>,
+}
+
+impl Drop for BerylliumBackend<'_> {
+  /// Because the backend parts are held in raw form, we have to manually,
+  /// carefully transmute them back to their "wrapped" form so that they can
+  /// perform their normal drop.
+  ///
+  /// Note: ManuallyDrop wouldn't improve things here, since the point of using
+  /// the raw forms is to fake out the lifetime system.
+  fn drop(&mut self) {
+    unsafe {
+      // We must drop the context first so it doesn't outlive the window.
+      let context: GLContext = core::mem::transmute(self.ctx);
+      drop(context);
+      let window: Window = core::mem::transmute(self.win_ptr);
+      drop(window);
+    }
   }
 }
-impl<'sdl> TryFrom<Window<'sdl>> for GliumWindow<'sdl> {
-  type Error = String;
-  fn try_from(win: Window) -> Result<Self, Self::Error> {
-    unimplemented!()
+
+impl<'sdl> BerylliumBackend<'sdl> {
+  /// Given just a window, creates a context and returns a backend.
+  ///
+  /// You have to have set the correct variables ahead of time so that the
+  /// correct context is created.
+  pub fn from_window(window: Window<'sdl>) -> Result<Self, String> {
+    unsafe {
+      let context: GLContext = window.gl_create_context()?;
+      let ctx: fermium::SDL_GLContext = core::mem::transmute(context);
+      let win_ptr: *mut fermium::SDL_Window = core::mem::transmute(window);
+      Ok(Self {
+        win_ptr,
+        ctx,
+        _marker: PhantomData,
+      })
+    }
+  }
+
+  /// Reference to the held Window.
+  pub fn window(&self) -> &Window<'sdl> {
+    let r: &*mut fermium::SDL_Window = &self.win_ptr;
+    unsafe { core::mem::transmute(r) }
+  }
+
+  /// Reference to the held GLContext
+  pub fn context(&self) -> &GLContext<'sdl, 'sdl> {
+    let r: &fermium::SDL_GLContext = &self.ctx;
+    unsafe { core::mem::transmute(r) }
+  }
+}
+
+/// We need to implement [glium::backend::Backend] so that we can use our
+/// backend type with [glium::backend::Context].
+unsafe impl Backend for BerylliumBackend<'_> {
+  fn swap_buffers(&self) -> Result<(), SwapBuffersError> {
+    // Note: this can't return error messages to us, so we can't pass any error
+    // messages to the caller. Good luck!
+    unsafe { self.window().gl_swap_window() };
+    Ok(())
+  }
+  unsafe fn get_proc_address(&self, symbol: &str) -> *const c_void {
+    // Note: We can make up a &SDLToken "out of nowhere" because if this window
+    // exists then naturally SDL2 is currently initialized. We choose a
+    // reference instead of an owned value so that we don't drop the token.
+    core::mem::transmute::<&(), &SDLToken>(&()).gl_get_proc_address(symbol)
+  }
+  fn get_framebuffer_dimensions(&self) -> (u32, u32) {
+    let (w, h) = unsafe { self.window().gl_get_drawable_size() };
+    (w as u32, h as u32)
+  }
+  fn is_current(&self) -> bool {
+    self.context().is_current()
+  }
+  unsafe fn make_current(&self) {
+    self
+      .window()
+      .gl_make_current(self.context())
+      .expect("Could not make the context current!")
+  }
+}
+
+/// Merges a Beryllium backend with a Glium context
+///
+/// Once again, we just lie to the compiler _a little bit_ to make our lives
+/// easier, and then fix it with phantom data.
+pub struct BerylliumFacade<'sdl> {
+  backend: Rc<BerylliumBackend<'static>>,
+  context: Rc<Context>,
+  _marker: PhantomData<&'sdl SDLToken>,
+}
+
+/// This is needed for general compatability with a lot of the glium stuff.
+impl Facade for BerylliumFacade<'_> {
+  fn get_context(&self) -> &Rc<Context> {
+    &self.context
+  }
+}
+
+impl<'sdl> BerylliumFacade<'sdl> {
+  /// Reference to the deeply wrapped Window.
+  pub fn window(&self) -> &Window {
+    self.backend.window()
+  }
+
+  /// Starts a new draw frame.
+  pub fn draw(&self) -> Frame {
+    Frame::new(
+      self.context.clone(),
+      self.backend.get_framebuffer_dimensions(),
+    )
+  }
+
+  /// Given a window, makes a facade.
+  ///
+  /// Because of shenanigans, you also need to pass a reference to the SDL
+  /// token.
+  pub fn from_window(window: Window<'_>, _t: &'sdl SDLToken) -> Result<Self, String> {
+    unsafe {
+      let window_static: Window<'static> = core::mem::transmute(window);
+      let backend = Rc::new(BerylliumBackend::from_window(window_static)?);
+      let context = Context::new(backend.clone(), true, DebugCallbackBehavior::default())
+        .map_err(|e| e.to_string())?;
+      Ok(Self {
+        backend,
+        context,
+        _marker: PhantomData,
+      })
+    }
   }
 }

--- a/examples/extern_crate_glium.rs
+++ b/examples/extern_crate_glium.rs
@@ -3,13 +3,21 @@
 //! Demo of how to setup a blank window using the `gl` crate for OpenGL.
 
 use beryllium::*;
-use gl;
+use glium;
+
+use core::convert::TryFrom;
+use core::ops::Deref;
 
 fn main() -> Result<(), String> {
-  // Init SDL2
+  // init SDL2
   let sdl = unsafe { beryllium::init() }?;
 
-  // Make a window (include the flag for OpenGL support!)
+  // Set our context request settings
+  sdl.gl_set_attribute(GLattr::ContextProfileMask, CONTEXT_PROFILE_CORE);
+  sdl.gl_set_attribute(GLattr::ContextMajorVersion, 3);
+  sdl.gl_set_attribute(GLattr::ContextMinorVersion, 3);
+
+  // make a window and then a context (which is automatically made current)
   let window = sdl.create_window(
     "Extern Crate: `gl`",                                      // title
     WINDOW_POSITION_CENTERED,                                  // x
@@ -18,14 +26,9 @@ fn main() -> Result<(), String> {
     600,                                                       // height
     WindowFlags::default().with_shown(true).with_opengl(true), // flags
   )?;
-
-  // Set our context request settings and make a context
-  sdl.gl_set_attribute(GLattr::ContextProfileMask, CONTEXT_PROFILE_CORE);
-  sdl.gl_set_attribute(GLattr::ContextMajorVersion, 3);
-  sdl.gl_set_attribute(GLattr::ContextMinorVersion, 3);
   let _ctx = unsafe { window.gl_create_context()? };
 
-  // ONCE WE HAVE A CONTEXT (not before!) we can load up the OpenGL functions
+  // ONCE WE HAVE A CONTEXT we can load up OpenGL (not before!)
   gl::load_with(|s| unsafe { sdl.gl_get_proc_address(s) });
 
   unsafe { gl::ClearColor(1.0, 0.5, 0.0, 1.0) };
@@ -50,4 +53,18 @@ fn main() -> Result<(), String> {
   }
 
   Ok(())
+}
+
+pub struct GliumWindow<'sdl>(Window<'sdl>);
+impl<'sdl> Deref for GliumWindow<'sdl> {
+  type Target = Window<'sdl>;
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+impl<'sdl> TryFrom<Window<'sdl>> for GliumWindow<'sdl> {
+  type Error = String;
+  fn try_from(win: Window) -> Result<Self, Self::Error> {
+    unimplemented!()
+  }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -668,6 +668,15 @@ impl<'sdl> Window<'sdl> {
   pub unsafe fn gl_swap_window(&self) {
     SDL_GL_SwapWindow(self.ptr)
   }
+
+  pub unsafe fn gl_make_current(&self, ctx: &GLContext) -> Result<(), String> {
+    let out = unsafe { SDL_GL_MakeCurrent(self.ptr, ctx.ctx) };
+    if out == 0 {
+      Ok(())
+    } else {
+      Err(get_error())
+    }
+  }
 }
 
 /// The window's fullscreen style.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,12 @@
 //! will mostly be locked into just the `main` thread. This isn't a huge deal in
 //! practice, but it's something that people might want to know up font.
 //!
+//! ## Safety
+//!
+//! As much as possible, SDL2 is carefully wrapped into a safe interface for you
+//! to use. That said, there's a few points that still can't be made 100% safe,
+//! so you will have to use `unsafe` in some places.
+//!
 //! ## Lifetimes
 //!
 //! Sadly, we gotta track some lifetimes here. Anything with a heap allocation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ use core::{
   convert::TryFrom,
   ffi::c_void,
   marker::PhantomData,
-  ops::Deref,
   ptr::{null, null_mut, NonNull},
   slice::from_raw_parts,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -669,8 +669,9 @@ impl<'sdl> Window<'sdl> {
     SDL_GL_SwapWindow(self.ptr)
   }
 
+  /// Makes the given context the current context in this window.
   pub unsafe fn gl_make_current(&self, ctx: &GLContext) -> Result<(), String> {
-    let out = unsafe { SDL_GL_MakeCurrent(self.ptr, ctx.ctx) };
+    let out = SDL_GL_MakeCurrent(self.ptr, ctx.ctx);
     if out == 0 {
       Ok(())
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,21 @@
 //! `CreateFoo`/`DestroyFoo` pairs for creation and destruction have been
 //! replaced with just using `new_foo` for creation and [Drop](Drop) for
 //! cleanup.
+//!
+//! ## Organization
+//!
+//! Internally the code is split up into modules because that's easier to work
+//! with, however the public API is that everything is just at the top level of
+//! the crate because that's far easier to work with. The only down side to this
+//! is that some compiler error messages will list the internal module name in
+//! the path. It's a little annoying, but that's more the fault of `rustc` than
+//! anything else.
+//!
+//! ## Failures
+//!
+//! If a call returns [Option](Option) or [Result](Result), I will make an
+//! effort to document what's likely to cause that. However, it's always
+//! possible that additional error conditions might exist.
 
 use core::{
   convert::TryFrom,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -828,36 +828,6 @@ impl<'sdl, 'win, 'ren> Drop for Texture<'sdl, 'win, 'ren> {
   }
 }
 
-/// A standard color, separate from any format.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-#[repr(C)]
-pub struct Color {
-  r: u8,
-  g: u8,
-  b: u8,
-  a: u8,
-}
-impl From<SDL_Color> for Color {
-  fn from(other: SDL_Color) -> Self {
-    Self {
-      r: other.r,
-      g: other.g,
-      b: other.b,
-      a: other.a,
-    }
-  }
-}
-impl From<Color> for SDL_Color {
-  fn from(other: Color) -> Self {
-    Self {
-      r: other.r,
-      g: other.g,
-      b: other.b,
-      a: other.a,
-    }
-  }
-}
-
 /// Rectangle struct, origin at the upper left.
 ///
 /// Naturally, having the origin at the upper left is a terrible and heretical

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use core::{
   convert::TryFrom,
   ffi::c_void,
   marker::PhantomData,
+  ops::{Deref, DerefMut},
   ptr::{null, null_mut, NonNull},
   slice::from_raw_parts,
 };
@@ -36,6 +37,12 @@ pub use audio::*;
 
 mod opengl;
 pub use opengl::*;
+
+mod pixel_format;
+pub use pixel_format::*;
+
+mod palette;
+pub use palette::*;
 
 /// Grabs up the data from a null terminated string pointer.
 unsafe fn gather_string(ptr: *const c_char) -> String {
@@ -753,7 +760,7 @@ impl<'sdl, 'win, 'ren> Drop for Texture<'sdl, 'win, 'ren> {
 }
 
 /// A standard color, separate from any format.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[repr(C)]
 pub struct Color {
   r: u8,
@@ -763,6 +770,16 @@ pub struct Color {
 }
 impl From<SDL_Color> for Color {
   fn from(other: SDL_Color) -> Self {
+    Self {
+      r: other.r,
+      g: other.g,
+      b: other.b,
+      a: other.a,
+    }
+  }
+}
+impl From<Color> for SDL_Color {
+  fn from(other: Color) -> Self {
     Self {
       r: other.r,
       g: other.g,
@@ -795,365 +812,15 @@ impl From<SDL_Rect> for Rect {
     }
   }
 }
-
-/// The various named pixel formats that SDL2 supports.
-///
-/// There's various checks you can perform on each pixel format.
-///
-/// Note that the "fourcc" formats, anything that gives `true` from the
-/// [is_fourcc](PixelFormatEnum::is_fourcc) method, are industry specified special
-/// values, and do not follow SDL2's bit packing scheme. In other words, the
-/// output they produce for any of the other check methods is not to really be
-/// trusted.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(windows, repr(i32))]
-#[cfg_attr(not(windows), repr(u32))]
-#[allow(missing_docs)]
-pub enum PixelFormatEnum {
-  Unknown = SDL_PIXELFORMAT_UNKNOWN,
-  Index1lsb = SDL_PIXELFORMAT_INDEX1LSB,
-  Index1msb = SDL_PIXELFORMAT_INDEX1MSB,
-  Index4lsb = SDL_PIXELFORMAT_INDEX4LSB,
-  Index4msb = SDL_PIXELFORMAT_INDEX4MSB,
-  Index8 = SDL_PIXELFORMAT_INDEX8,
-  RGB332 = SDL_PIXELFORMAT_RGB332,
-  RGB444 = SDL_PIXELFORMAT_RGB444,
-  RGB555 = SDL_PIXELFORMAT_RGB555,
-  BGR555 = SDL_PIXELFORMAT_BGR555,
-  ARGB4444 = SDL_PIXELFORMAT_ARGB4444,
-  RGBA4444 = SDL_PIXELFORMAT_RGBA4444,
-  ABGR4444 = SDL_PIXELFORMAT_ABGR4444,
-  BGRA4444 = SDL_PIXELFORMAT_BGRA4444,
-  ARGB1555 = SDL_PIXELFORMAT_ARGB1555,
-  RGBA5551 = SDL_PIXELFORMAT_RGBA5551,
-  ABGR1555 = SDL_PIXELFORMAT_ABGR1555,
-  BGRA5551 = SDL_PIXELFORMAT_BGRA5551,
-  RGB565 = SDL_PIXELFORMAT_RGB565,
-  BGR565 = SDL_PIXELFORMAT_BGR565,
-  RGB24 = SDL_PIXELFORMAT_RGB24,
-  BGR24 = SDL_PIXELFORMAT_BGR24,
-  RGB888 = SDL_PIXELFORMAT_RGB888,
-  RGBX8888 = SDL_PIXELFORMAT_RGBX8888,
-  BGR888 = SDL_PIXELFORMAT_BGR888,
-  BGRX8888 = SDL_PIXELFORMAT_BGRX8888,
-  ARGB8888 = SDL_PIXELFORMAT_ARGB8888,
-  RGBA8888 = SDL_PIXELFORMAT_RGBA8888,
-  ABGR8888 = SDL_PIXELFORMAT_ABGR8888,
-  BGRA8888 = SDL_PIXELFORMAT_BGRA8888,
-  ARGB2101010 = SDL_PIXELFORMAT_ARGB2101010,
-  /// Planar mode: Y + V + U (3 planes)
-  YV12 = SDL_PIXELFORMAT_YV12,
-  /// Planar mode: Y + U + V (3 planes)
-  IYUV = SDL_PIXELFORMAT_IYUV,
-  /// Packed mode: Y0+U0+Y1+V0 (1 plane)
-  YUY2 = SDL_PIXELFORMAT_YUY2,
-  /// Packed mode: U0+Y0+V0+Y1 (1 plane)
-  UYVY = SDL_PIXELFORMAT_UYVY,
-  /// Packed mode: Y0+V0+Y1+U0 (1 plane)
-  YVYU = SDL_PIXELFORMAT_YVYU,
-  /// Planar mode: Y + U/V interleaved (2 planes)
-  NV12 = SDL_PIXELFORMAT_NV12,
-  /// Planar mode: Y + V/U interleaved (2 planes)
-  NV21 = SDL_PIXELFORMAT_NV21,
-  /// Android video texture format
-  ExternalOES = SDL_PIXELFORMAT_EXTERNAL_OES,
-}
-#[cfg(target_endian = "big")]
-impl PixelFormatEnum {
-  /// Platform specific alias for RGBA
-  pub const RGBA32: Self = PixelFormatEnum::RGBA8888;
-  /// Platform specific alias for ARGB
-  pub const ARGB32: Self = PixelFormatEnum::ARGB8888;
-  /// Platform specific alias for BGRA
-  pub const BGRA32: Self = PixelFormatEnum::BGRA8888;
-  /// Platform specific alias for ABGR
-  pub const ABGR32: Self = PixelFormatEnum::ABGR8888;
-}
-#[cfg(target_endian = "little")]
-impl PixelFormatEnum {
-  /// Platform specific alias for RGBA
-  pub const RGBA32: Self = PixelFormatEnum::ABGR8888;
-  /// Platform specific alias for ARGB
-  pub const ARGB32: Self = PixelFormatEnum::BGRA8888;
-  /// Platform specific alias for BGRA
-  pub const BGRA32: Self = PixelFormatEnum::ARGB8888;
-  /// Platform specific alias for ABGR
-  pub const ABGR32: Self = PixelFormatEnum::RGBA8888;
-}
-impl From<fermium::_bindgen_ty_6::Type> for PixelFormatEnum {
-  fn from(pf: fermium::_bindgen_ty_6::Type) -> Self {
-    match pf {
-      SDL_PIXELFORMAT_INDEX1LSB => PixelFormatEnum::Index1lsb,
-      SDL_PIXELFORMAT_INDEX1MSB => PixelFormatEnum::Index1msb,
-      SDL_PIXELFORMAT_INDEX4LSB => PixelFormatEnum::Index4lsb,
-      SDL_PIXELFORMAT_INDEX4MSB => PixelFormatEnum::Index4msb,
-      SDL_PIXELFORMAT_INDEX8 => PixelFormatEnum::Index8,
-      SDL_PIXELFORMAT_RGB332 => PixelFormatEnum::RGB332,
-      SDL_PIXELFORMAT_RGB444 => PixelFormatEnum::RGB444,
-      SDL_PIXELFORMAT_RGB555 => PixelFormatEnum::RGB555,
-      SDL_PIXELFORMAT_BGR555 => PixelFormatEnum::BGR555,
-      SDL_PIXELFORMAT_ARGB4444 => PixelFormatEnum::ARGB4444,
-      SDL_PIXELFORMAT_RGBA4444 => PixelFormatEnum::RGBA4444,
-      SDL_PIXELFORMAT_ABGR4444 => PixelFormatEnum::ABGR4444,
-      SDL_PIXELFORMAT_BGRA4444 => PixelFormatEnum::BGRA4444,
-      SDL_PIXELFORMAT_ARGB1555 => PixelFormatEnum::ARGB1555,
-      SDL_PIXELFORMAT_RGBA5551 => PixelFormatEnum::RGBA5551,
-      SDL_PIXELFORMAT_ABGR1555 => PixelFormatEnum::ABGR1555,
-      SDL_PIXELFORMAT_BGRA5551 => PixelFormatEnum::BGRA5551,
-      SDL_PIXELFORMAT_RGB565 => PixelFormatEnum::RGB565,
-      SDL_PIXELFORMAT_BGR565 => PixelFormatEnum::BGR565,
-      SDL_PIXELFORMAT_RGB24 => PixelFormatEnum::RGB24,
-      SDL_PIXELFORMAT_BGR24 => PixelFormatEnum::BGR24,
-      SDL_PIXELFORMAT_RGB888 => PixelFormatEnum::RGB888,
-      SDL_PIXELFORMAT_RGBX8888 => PixelFormatEnum::RGBX8888,
-      SDL_PIXELFORMAT_BGR888 => PixelFormatEnum::BGR888,
-      SDL_PIXELFORMAT_BGRX8888 => PixelFormatEnum::BGRX8888,
-      SDL_PIXELFORMAT_ARGB8888 => PixelFormatEnum::ARGB8888,
-      SDL_PIXELFORMAT_RGBA8888 => PixelFormatEnum::RGBA8888,
-      SDL_PIXELFORMAT_ABGR8888 => PixelFormatEnum::ABGR8888,
-      SDL_PIXELFORMAT_BGRA8888 => PixelFormatEnum::BGRA8888,
-      SDL_PIXELFORMAT_ARGB2101010 => PixelFormatEnum::ARGB2101010,
-      SDL_PIXELFORMAT_YV12 => PixelFormatEnum::YV12,
-      SDL_PIXELFORMAT_IYUV => PixelFormatEnum::IYUV,
-      SDL_PIXELFORMAT_YUY2 => PixelFormatEnum::YUY2,
-      SDL_PIXELFORMAT_UYVY => PixelFormatEnum::UYVY,
-      SDL_PIXELFORMAT_YVYU => PixelFormatEnum::YVYU,
-      SDL_PIXELFORMAT_NV12 => PixelFormatEnum::NV12,
-      SDL_PIXELFORMAT_NV21 => PixelFormatEnum::NV21,
-      SDL_PIXELFORMAT_EXTERNAL_OES => PixelFormatEnum::ExternalOES,
-      _ => PixelFormatEnum::Unknown,
+impl From<Rect> for SDL_Rect {
+  fn from(other: Rect) -> Self {
+    Self {
+      x: other.x,
+      y: other.y,
+      w: other.w,
+      h: other.h,
     }
   }
-}
-impl PixelFormatEnum {
-  /// The type of the pixel format.
-  ///
-  /// All unknown types convert to `PixelType::Unknown`, of course.
-  pub fn pixel_type(self) -> PixelType {
-    match ((self as u32 >> 24) & 0x0F) as fermium::_bindgen_ty_1::Type {
-      SDL_PIXELTYPE_INDEX1 => PixelType::Index1,
-      SDL_PIXELTYPE_INDEX4 => PixelType::Index4,
-      SDL_PIXELTYPE_INDEX8 => PixelType::Index8,
-      SDL_PIXELTYPE_PACKED8 => PixelType::Packed8,
-      SDL_PIXELTYPE_PACKED16 => PixelType::Packed16,
-      SDL_PIXELTYPE_PACKED32 => PixelType::Packed32,
-      SDL_PIXELTYPE_ARRAYU8 => PixelType::ArrayU8,
-      SDL_PIXELTYPE_ARRAYU16 => PixelType::ArrayU16,
-      SDL_PIXELTYPE_ARRAYU32 => PixelType::ArrayU32,
-      SDL_PIXELTYPE_ARRAYF16 => PixelType::ArrayF16,
-      SDL_PIXELTYPE_ARRAYF32 => PixelType::ArrayF32,
-      _ => PixelType::Unknown,
-    }
-  }
-
-  /// Ordering of channel or bits in the pixel format.
-  ///
-  /// Unknown values convert to one of the `None` variants.
-  pub fn pixel_order(self) -> PixelOrder {
-    let bits = (self as u32 >> 20) & 0x0F;
-    if self.is_packed() {
-      match bits as fermium::_bindgen_ty_4::Type {
-        SDL_PACKEDORDER_ABGR => PixelOrder::Packed(PackedPixelOrder::ABGR),
-        SDL_PACKEDORDER_ARGB => PixelOrder::Packed(PackedPixelOrder::ARGB),
-        SDL_PACKEDORDER_BGRA => PixelOrder::Packed(PackedPixelOrder::BGRA),
-        SDL_PACKEDORDER_BGRX => PixelOrder::Packed(PackedPixelOrder::BGRX),
-        SDL_PACKEDORDER_RGBA => PixelOrder::Packed(PackedPixelOrder::RGBA),
-        SDL_PACKEDORDER_RGBX => PixelOrder::Packed(PackedPixelOrder::RGBX),
-        SDL_PACKEDORDER_XBGR => PixelOrder::Packed(PackedPixelOrder::XBGR),
-        SDL_PACKEDORDER_XRGB => PixelOrder::Packed(PackedPixelOrder::XRGB),
-        _ => PixelOrder::Packed(PackedPixelOrder::None),
-      }
-    } else if self.is_array() {
-      match bits as fermium::_bindgen_ty_4::Type {
-        SDL_ARRAYORDER_ABGR => PixelOrder::Array(ArrayPixelOrder::ABGR),
-        SDL_ARRAYORDER_ARGB => PixelOrder::Array(ArrayPixelOrder::ARGB),
-        SDL_ARRAYORDER_BGR => PixelOrder::Array(ArrayPixelOrder::BGR),
-        SDL_ARRAYORDER_BGRA => PixelOrder::Array(ArrayPixelOrder::BGRA),
-        SDL_ARRAYORDER_RGB => PixelOrder::Array(ArrayPixelOrder::RGB),
-        SDL_ARRAYORDER_RGBA => PixelOrder::Array(ArrayPixelOrder::RGBA),
-        _ => PixelOrder::Array(ArrayPixelOrder::None),
-      }
-    } else {
-      match bits as fermium::_bindgen_ty_2::Type {
-        SDL_BITMAPORDER_1234 => PixelOrder::Bitmap(BitmapPixelOrder::_1234),
-        SDL_BITMAPORDER_4321 => PixelOrder::Bitmap(BitmapPixelOrder::_4321),
-        _ => PixelOrder::Bitmap(BitmapPixelOrder::None),
-      }
-    }
-  }
-
-  /// Channel bits pattern of the pixel format.
-  ///
-  /// Converts any possible unknown layout to `PixelLayout::None`.
-  pub fn pixel_layout(self) -> PixelLayout {
-    match ((self as u32 >> 16) & 0x0F) as fermium::_bindgen_ty_1::Type {
-      SDL_PACKEDLAYOUT_332 => PixelLayout::_332,
-      SDL_PACKEDLAYOUT_4444 => PixelLayout::_4444,
-      SDL_PACKEDLAYOUT_1555 => PixelLayout::_1555,
-      SDL_PACKEDLAYOUT_5551 => PixelLayout::_5551,
-      SDL_PACKEDLAYOUT_565 => PixelLayout::_565,
-      SDL_PACKEDLAYOUT_8888 => PixelLayout::_8888,
-      SDL_PACKEDLAYOUT_2101010 => PixelLayout::_2101010,
-      SDL_PACKEDLAYOUT_1010102 => PixelLayout::_1010102,
-      _ => PixelLayout::None,
-    }
-  }
-
-  /// Bits of color information per pixel.
-  pub fn bits_per_pixel(self) -> u32 {
-    (self as u32 >> 8) & 0xFF
-  }
-
-  /// Bytes used per pixel.
-  ///
-  /// Note: Formats with less than 8 bits per pixel give a result of 0 bytes per
-  /// pixel. Weird and all, but that's how it is.
-  pub fn bytes_per_pixel(self) -> u32 {
-    if self.is_fourcc() {
-      match self {
-        PixelFormatEnum::YUY2 | PixelFormatEnum::UYVY | PixelFormatEnum::YVYU => 2,
-        _ => 1,
-      }
-    } else {
-      self as u32 & 0xFF
-    }
-  }
-
-  /// Is this format an indexed format?
-  pub fn is_indexed(self) -> bool {
-    !self.is_fourcc()
-      && match self.pixel_type() {
-        PixelType::Index1 | PixelType::Index4 | PixelType::Index8 => true,
-        _ => false,
-      }
-  }
-
-  /// Is this format a packed format?
-  pub fn is_packed(self) -> bool {
-    !self.is_fourcc()
-      && match self.pixel_type() {
-        PixelType::Packed8 | PixelType::Packed16 | PixelType::Packed32 => true,
-        _ => false,
-      }
-  }
-
-  /// Is this format a packed format?
-  pub fn is_array(self) -> bool {
-    !self.is_fourcc()
-      && match self.pixel_type() {
-        PixelType::ArrayU8
-        | PixelType::ArrayU16
-        | PixelType::ArrayU32
-        | PixelType::ArrayF16
-        | PixelType::ArrayF32 => true,
-        _ => false,
-      }
-  }
-
-  /// Is this format a format with an alpha channel?
-  pub fn is_alpha(self) -> bool {
-    match self.pixel_order() {
-      PixelOrder::Packed(PackedPixelOrder::ARGB)
-      | PixelOrder::Packed(PackedPixelOrder::RGBA)
-      | PixelOrder::Packed(PackedPixelOrder::ABGR)
-      | PixelOrder::Packed(PackedPixelOrder::BGRA)
-      | PixelOrder::Array(ArrayPixelOrder::ARGB)
-      | PixelOrder::Array(ArrayPixelOrder::RGBA)
-      | PixelOrder::Array(ArrayPixelOrder::ABGR)
-      | PixelOrder::Array(ArrayPixelOrder::BGRA) => true,
-      _ => false,
-    }
-  }
-
-  /// Is this a [four-character code](https://en.wikipedia.org/wiki/FourCC) format?
-  ///
-  /// True for pixel formats representing unique formats, for example YUV formats.
-  pub fn is_fourcc(self) -> bool {
-    (self as u32 > 0) && (((self as u32 >> 28) & 0x0F) != 1)
-  }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(windows, repr(i32))]
-#[cfg_attr(not(windows), repr(u32))]
-#[allow(missing_docs)]
-pub enum PixelType {
-  Unknown = SDL_PIXELTYPE_UNKNOWN,
-  Index1 = SDL_PIXELTYPE_INDEX1,
-  Index4 = SDL_PIXELTYPE_INDEX4,
-  Index8 = SDL_PIXELTYPE_INDEX8,
-  Packed8 = SDL_PIXELTYPE_PACKED8,
-  Packed16 = SDL_PIXELTYPE_PACKED16,
-  Packed32 = SDL_PIXELTYPE_PACKED32,
-  ArrayU8 = SDL_PIXELTYPE_ARRAYU8,
-  ArrayU16 = SDL_PIXELTYPE_ARRAYU16,
-  ArrayU32 = SDL_PIXELTYPE_ARRAYU32,
-  ArrayF16 = SDL_PIXELTYPE_ARRAYF16,
-  ArrayF32 = SDL_PIXELTYPE_ARRAYF32,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(missing_docs)]
-pub enum PixelOrder {
-  Bitmap(BitmapPixelOrder),
-  Packed(PackedPixelOrder),
-  Array(ArrayPixelOrder),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(windows, repr(i32))]
-#[cfg_attr(not(windows), repr(u32))]
-#[allow(missing_docs)]
-pub enum BitmapPixelOrder {
-  None = SDL_BITMAPORDER_NONE,
-  _4321 = SDL_BITMAPORDER_4321,
-  _1234 = SDL_BITMAPORDER_1234,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(windows, repr(i32))]
-#[cfg_attr(not(windows), repr(u32))]
-#[allow(missing_docs)]
-pub enum PackedPixelOrder {
-  None = SDL_PACKEDORDER_NONE,
-  XRGB = SDL_PACKEDORDER_XRGB,
-  RGBX = SDL_PACKEDORDER_RGBX,
-  ARGB = SDL_PACKEDORDER_ARGB,
-  RGBA = SDL_PACKEDORDER_RGBA,
-  XBGR = SDL_PACKEDORDER_XBGR,
-  BGRX = SDL_PACKEDORDER_BGRX,
-  ABGR = SDL_PACKEDORDER_ABGR,
-  BGRA = SDL_PACKEDORDER_BGRA,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(windows, repr(i32))]
-#[cfg_attr(not(windows), repr(u32))]
-#[allow(missing_docs)]
-pub enum ArrayPixelOrder {
-  None = SDL_ARRAYORDER_NONE,
-  RGB = SDL_ARRAYORDER_RGB,
-  RGBA = SDL_ARRAYORDER_RGBA,
-  ARGB = SDL_ARRAYORDER_ARGB,
-  BGR = SDL_ARRAYORDER_BGR,
-  BGRA = SDL_ARRAYORDER_BGRA,
-  ABGR = SDL_ARRAYORDER_ABGR,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(windows, repr(i32))]
-#[cfg_attr(not(windows), repr(u32))]
-#[allow(missing_docs)]
-pub enum PixelLayout {
-  None = SDL_PACKEDLAYOUT_NONE,
-  _332 = SDL_PACKEDLAYOUT_332,
-  _4444 = SDL_PACKEDLAYOUT_4444,
-  _1555 = SDL_PACKEDLAYOUT_1555,
-  _5551 = SDL_PACKEDLAYOUT_5551,
-  _565 = SDL_PACKEDLAYOUT_565,
-  _8888 = SDL_PACKEDLAYOUT_8888,
-  _2101010 = SDL_PACKEDLAYOUT_2101010,
-  _1010102 = SDL_PACKEDLAYOUT_1010102,
 }
 
 /// Handle to a C ABI dynamic library that has been loaded.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations)]
+#![allow(clippy::needless_lifetimes)]
 // The unsafe code relies on the idea that `usize` is at least `u32`
 #![cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations)]
+// The unsafe code relies on the idea that `usize` is at least `u32`
 #![cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 
 //! An opinionated set of "high level" wrappers for the
@@ -9,7 +10,7 @@ use core::{
   convert::TryFrom,
   ffi::c_void,
   marker::PhantomData,
-  ops::{Deref, DerefMut},
+  ops::Deref,
   ptr::{null, null_mut, NonNull},
   slice::from_raw_parts,
 };

--- a/src/opengl.rs
+++ b/src/opengl.rs
@@ -149,6 +149,7 @@ impl<'sdl, 'win> GLContext<'sdl, 'win> {
     }
   }
 
+  /// Checks if this context is current.
   pub fn is_current(&self) -> bool {
     let cur = unsafe { SDL_GL_GetCurrentContext() };
     self.ctx == cur

--- a/src/opengl.rs
+++ b/src/opengl.rs
@@ -1,0 +1,151 @@
+use super::*;
+
+/// Attributes that you can use to control OpenGL's loading and context creation
+/// process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(windows, repr(i32))]
+#[cfg_attr(not(windows), repr(u32))]
+pub enum GLattr {
+  /// the minimum number of bits for the red channel of the color buffer; defaults to 3
+  RedSize = SDL_GL_RED_SIZE,
+
+  /// the minimum number of bits for the green channel of the color buffer; defaults to 3
+  GreenSize = SDL_GL_GREEN_SIZE,
+
+  /// the minimum number of bits for the blue channel of the color buffer; defaults to 2
+  BlueSize = SDL_GL_BLUE_SIZE,
+
+  /// the minimum number of bits for the alpha channel of the color buffer; defaults to 0
+  AlphaSize = SDL_GL_ALPHA_SIZE,
+
+  /// the minimum number of bits for frame buffer size; defaults to 0
+  BufferSize = SDL_GL_BUFFER_SIZE,
+
+  /// whether the output is single or double buffered; defaults to double buffering on
+  DoubleBuffer = SDL_GL_DOUBLEBUFFER,
+
+  /// the minimum number of bits in the depth buffer; defaults to 16
+  DepthSize = SDL_GL_DEPTH_SIZE,
+
+  /// the minimum number of bits in the stencil buffer; defaults to 0
+  StencilSize = SDL_GL_STENCIL_SIZE,
+
+  /// the minimum number of bits for the red channel of the accumulation buffer; defaults to 0
+  AccumRedSize = SDL_GL_ACCUM_RED_SIZE,
+
+  /// the minimum number of bits for the green channel of the accumulation buffer; defaults to 0
+  AccumGreenSize = SDL_GL_ACCUM_GREEN_SIZE,
+
+  /// the minimum number of bits for the blue channel of the accumulation buffer; defaults to 0
+  AccumBlueSize = SDL_GL_ACCUM_BLUE_SIZE,
+
+  /// the minimum number of bits for the alpha channel of the accumulation buffer; defaults to 0
+  AccumAlphaSize = SDL_GL_ACCUM_ALPHA_SIZE,
+
+  /// whether the output is stereo 3D; defaults to off
+  Stereo = SDL_GL_STEREO,
+
+  /// the number of buffers used for multisample anti-aliasing; defaults to 0; see Remarks for details
+  MultisampleBuffers = SDL_GL_MULTISAMPLEBUFFERS,
+
+  /// the number of samples used around the current pixel used for multisample anti-aliasing; defaults to 0; see Remarks for details
+  MultisampleSamples = SDL_GL_MULTISAMPLESAMPLES,
+
+  /// set to 1 to require hardware acceleration, set to 0 to force software rendering; defaults to allow either
+  AcceleratedVisuals = SDL_GL_ACCELERATED_VISUAL,
+
+  /// OpenGL context major version
+  ContextMajorVersion = SDL_GL_CONTEXT_MAJOR_VERSION,
+
+  /// OpenGL context minor version
+  ContextMinorVersion = SDL_GL_CONTEXT_MINOR_VERSION,
+
+  /// some combination of 0 or more of elements of the SDL_GLcontextFlag enumeration; defaults to 0
+  ContextFlags = SDL_GL_CONTEXT_FLAGS,
+
+  /// type of GL context (Core, Compatibility, ES), default value depends on platform
+  ContextProfileMask = SDL_GL_CONTEXT_PROFILE_MASK,
+
+  /// OpenGL context sharing; defaults to 0
+  ShareWithCurrentContext = SDL_GL_SHARE_WITH_CURRENT_CONTEXT,
+
+  /// requests sRGB capable visual; defaults to 0
+  FramebufferSRGBCapable = SDL_GL_FRAMEBUFFER_SRGB_CAPABLE,
+
+  /// sets context the release behavior; defaults to 1
+  ContextReleaseBehavior = SDL_GL_CONTEXT_RELEASE_BEHAVIOR,
+}
+
+/// Requests an OpenGL Compatibility context.
+pub const CONTEXT_PROFILE_COMPATIBILITY: i32 = SDL_GL_CONTEXT_PROFILE_COMPATIBILITY as i32;
+
+/// Requests an OpenGL Core context.
+pub const CONTEXT_PROFILE_CORE: i32 = SDL_GL_CONTEXT_PROFILE_CORE as i32;
+
+/// Requests an OpenGL ES context.
+pub const CONTEXT_PROFILE_ES: i32 = SDL_GL_CONTEXT_PROFILE_ES as i32;
+
+/// Handle for an OpenGL context.
+///
+/// # General Safety
+///
+/// The context must be current when you call any method here.
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct GLContext<'sdl, 'win> {
+  pub(crate) ctx: SDL_GLContext,
+  pub(crate) _marker: PhantomData<&'win Window<'sdl>>,
+}
+impl<'sdl, 'win> Drop for GLContext<'sdl, 'win> {
+  fn drop(&mut self) {
+    unsafe { SDL_GL_DeleteContext(self.ctx) }
+  }
+}
+impl<'sdl, 'win> GLContext<'sdl, 'win> {
+  /// Checks if the given extension is available in this context.
+  pub unsafe fn extension_supported(&self, name: &str) -> bool {
+    let name_null: Vec<u8> = name.bytes().chain(Some(0)).collect();
+    SDL_TRUE == SDL_GL_ExtensionSupported(name_null.as_ptr() as *const c_char)
+  }
+
+  /// Obtains the actual value of the attribute for this context.
+  ///
+  /// Note that the context you request and the context that you get might not
+  /// match, because yay.
+  pub unsafe fn get_attribute(&self, attr: GLattr) -> Result<i32, String> {
+    let mut output = 0;
+    if 0 == SDL_GL_GetAttribute(attr as fermium::SDL_GLattr::Type, &mut output) {
+      Ok(output)
+    } else {
+      Err(get_error())
+    }
+  }
+
+  /// Determines the swap interval of the video display.
+  ///
+  /// * 0: No vsync
+  /// * 1: Vsync
+  /// * -1: "adaptive vsync", late swaps will happen immediately
+  ///
+  /// If the swap interval can't be determined this returns 0 as a "safe
+  /// default". You can also call [get_error](get_error) to potentially find out
+  /// more.
+  pub unsafe fn swap_interval(&self) -> i32 {
+    SDL_GL_GetSwapInterval()
+  }
+
+  /// Attempts to set the swap interval value.
+  ///
+  /// The values work as per [swap_interval](GLContext::swap_interval).
+  ///
+  /// Note that if you request adaptive vsync and get an error it is likely that
+  /// standard vsync might still be available as a fallback.
+  pub unsafe fn set_swap_interval(&self, interval: i32) -> Result<(), String> {
+    let out = SDL_GL_SetSwapInterval(interval);
+    if out == 0 {
+      Ok(())
+    } else {
+      Err(get_error())
+    }
+  }
+}

--- a/src/opengl.rs
+++ b/src/opengl.rs
@@ -148,4 +148,9 @@ impl<'sdl, 'win> GLContext<'sdl, 'win> {
       Err(get_error())
     }
   }
+
+  pub fn is_current(&self) -> bool {
+    let cur = unsafe { SDL_GL_GetCurrentContext() };
+    self.ctx == cur
+  }
 }

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -2,18 +2,13 @@ use super::*;
 
 /// A palette of [Color](Color) values.
 ///
-/// The way that the `Palette` type works is very different from Rust's normal
+/// The way that the `Palette` type works is different from Rust's normal
 /// ownership model, so please pay attention as I explain.
 ///
 /// A `Palette` value holds a pointer to a heap allocated
-/// [SDL_Palette](SDL_Palette). That `SDL_Palette` has a pointer to the heap
-/// allocated `Color` values, along with a length, reference count, and version
-/// number.
-///
-/// You allocate a `Palette` by calling
-/// [SDLToken::new_palette](SDLToken::new_palette) and specifying how many
-/// `Color` values the `Palette` should hold. All slots in a new `Palette` are
-/// initialized to opaque white (`0xFF` in all four color channel).
+/// [SDL_Palette](SDL_Palette) ([wiki](https://wiki.libsdl.org/SDL_Palette)).
+/// That `SDL_Palette` has a pointer to the heap allocated `Color` values, along
+/// with a length, reference count, and version number.
 ///
 /// When you set a Palette on a [Surface](Surface) or [PixelFormat](PixelFormat)
 /// it moves some pointers and adjusts the reference count of the `Palette`. Now
@@ -22,9 +17,20 @@ use super::*;
 ///
 /// As a result, I cannot allow you to _ever_ construct a shared reference or
 /// unique reference to the `Color` data held inside the `Palette`. This means
-/// no [Deref](Deref), [Index](Index), or [IndexMut](IndexMut), no Iterators of
-/// any kind, none of that. This definitely makes the API of the `Palette` type
-/// not quite as fun as you might like.
+/// no [Deref](core::ops::Deref), [Index](core::ops::Index), or
+/// [IndexMut](core::ops::IndexMut), no Iterators of any kind, none of that.
+/// This definitely makes the API of the `Palette` type not quite as fun as you
+/// might like.
+///
+/// You can allocate a `Palette` by calling
+/// [SDLToken::new_palette](SDLToken::new_palette) and specifying how many
+/// `Color` values the `Palette` should hold. However, you generally do not need
+/// to do this yourself, because if a `Surface` or `PixelFormat` needs palette
+/// data it will automatically allocate a palette of the correct size when it is
+/// created.
+///
+/// All slots in a new `Palette` are initialized to opaque white (`0xFF` in all
+/// four color channels).
 #[derive(Debug)] // TODO: We probably want a custom Debug impl
 #[repr(transparent)]
 pub struct Palette<'sdl> {

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -1,5 +1,49 @@
 use super::*;
 
+/// An abstract RGBA color value.
+///
+/// * Each channel ranges from 0 (none) to 255 (maximum).
+/// * Alpha channel is "opacity", so 255 is opaque.
+///
+/// A color value's exact representation within an image depends on the
+/// [PixelFormat](PixelFormat) of the image. You can use the "get" and "map"
+/// methods of a `PixelFormat` to convert between raw pixel data and a `Color`
+/// value. Note that any `PixelFormat` that's less than 32 bits per pixel will
+/// lose information when you go from `Color` to raw pixel value, so the
+/// conversion isn't always reversible.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[repr(C)]
+pub struct Color {
+  /// Red
+  pub r: u8,
+  /// Green
+  pub g: u8,
+  /// Blue
+  pub b: u8,
+  /// Alpha / opacity
+  pub a: u8,
+}
+impl From<SDL_Color> for Color {
+  fn from(other: SDL_Color) -> Self {
+    Self {
+      r: other.r,
+      g: other.g,
+      b: other.b,
+      a: other.a,
+    }
+  }
+}
+impl From<Color> for SDL_Color {
+  fn from(other: Color) -> Self {
+    Self {
+      r: other.r,
+      g: other.g,
+      b: other.b,
+      a: other.a,
+    }
+  }
+}
+
 /// A palette of [Color](Color) values.
 ///
 /// The way that the `Palette` type works is slightly different from Rust's

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -120,6 +120,19 @@ impl Palette<'_> {
       Some(unsafe { (*(*self.nn.as_ptr()).colors.add(index)).into() })
     }
   }
+
+  /// Creates a new [Vec](Vec) with the same colors as this `Palette`.
+  pub fn to_vec(&self) -> Vec<Color> {
+    // Note(Lokathor): This is safe only as long as this slice never leaves
+    // this function call.
+    let self_slice = unsafe {
+      core::slice::from_raw_parts(
+        (*self.nn.as_ptr()).colors as *mut Color,
+        (*self.nn.as_ptr()).ncolors as usize,
+      )
+    };
+    self_slice.to_vec()
+  }
 }
 
 impl Clone for Palette<'_> {
@@ -141,14 +154,14 @@ impl Clone for Palette<'_> {
           nn,
           _marker: PhantomData,
         };
-        // Note(Lokathor): This is safe because
+        // Note(Lokathor): This is safe only as long as this slice never leaves
+        // this function call.
         let self_slice = unsafe {
           core::slice::from_raw_parts(
             (*self.nn.as_ptr()).colors as *mut Color,
             (*self.nn.as_ptr()).ncolors as usize,
           )
         };
-
         out
           .set_colors(0, self_slice)
           .expect("Failed to copy the color data!");

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -64,6 +64,7 @@ impl SDLToken {
   }
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl<'sdl> Palette<'sdl> {
   /// Gets the number of colors in the Palette
   pub fn len(&self) -> usize {
@@ -73,7 +74,7 @@ impl<'sdl> Palette<'sdl> {
   /// Gets the [Color](Color) at the index specified.
   pub fn get_color(&self, index: usize) -> Option<Color> {
     if index < self.len() {
-      Some(unsafe { (*(*self.ptr).colors.offset(index as isize)).into() })
+      Some(unsafe { (*(*self.ptr).colors.add(index)).into() })
     } else {
       None
     }

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -72,9 +72,8 @@ impl<'sdl> Palette<'sdl> {
   /// palette colors and we have to go though that, which normal use of the
   /// `IndexMut` trait would not do.
   ///
-  /// `start` values out of bounds give an error. If the starting point for the
-  /// slice would cause it to copy off the end of this Palette the input slice
-  /// is truncated and it copies as many colors as possible.
+  /// `start` values >= the length will give an error. The input slice is
+  /// automatically clipped as necessary, so as to not go out of bounds.
   pub fn set_colors(&mut self, start: usize, new_colors: &[Color]) -> Result<(), String> {
     if start >= self.len() {
       return Err("beryllium error: start index out of bounds".to_string());
@@ -82,6 +81,7 @@ impl<'sdl> Palette<'sdl> {
     // We'll manually clip the input slice instead of relying on SDL2's dubious
     // clipping process.
     let clipped_new_colors = &new_colors[..(self.len() - start).min(new_colors.len())];
+    debug_assert!(start + clipped_new_colors.len() <= self.len());
     let out = unsafe {
       SDL_SetPaletteColors(
         self.ptr,

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -6,11 +6,11 @@ use super::*;
 /// * Alpha channel is "opacity", so 255 is opaque.
 ///
 /// A color value's exact representation within an image depends on the
-/// [PixelFormat](PixelFormat) of the image. You can use the "get" and "map"
-/// methods of a `PixelFormat` to convert between raw pixel data and a `Color`
-/// value. Note that any `PixelFormat` that's less than 32 bits per pixel will
-/// lose information when you go from `Color` to raw pixel value, so the
-/// conversion isn't always reversible.
+/// [PixelFormat] of the image. You can use the "get" and "map" methods of a
+/// `PixelFormat` to convert between raw pixel data and a `Color` value. Note
+/// that any `PixelFormat` that's less than 32 bits per pixel will lose
+/// information when you go from `Color` to raw pixel value, so the conversion
+/// isn't always reversible.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[repr(C)]
 pub struct Color {
@@ -44,22 +44,22 @@ impl From<Color> for SDL_Color {
   }
 }
 
-/// A palette of [Color](Color) values.
+/// A palette of [Color] values.
 ///
 /// The way that the `Palette` type works is slightly different from Rust's
 /// normal ownership model, so please pay attention as I explain.
 ///
-/// A `Palette` value holds a pointer to a heap allocated
-/// [SDL_Palette](SDL_Palette) ([wiki](https://wiki.libsdl.org/SDL_Palette)).
-/// That `SDL_Palette` has a pointer to the heap allocated `Color` values, along
-/// with a length, reference count, and version number.
+/// A `Palette` value holds a pointer to a heap allocated [SDL_Palette]
+/// ([wiki](https://wiki.libsdl.org/SDL_Palette)). That `SDL_Palette` has a
+/// pointer to the heap allocated `Color` values, along with a length, reference
+/// count, and version number.
 ///
-/// When you set a `Palette` on a [Surface](Surface) or [PixelFormat](PixelFormat)
-/// it moves some pointers and adjusts the reference count of the `Palette`. Now
-/// you have the `Palette`, and _also_ that thing has the same `Palette`. An
-/// edit to the `Palette` data in either location will affect everyone's data.
-/// Having a `&mut Palette` does _not_ mean that you have an exclusive path of
-/// access to the `Palette` contents.
+/// When you set a `Palette` on a [Surface] or [PixelFormat] it moves some
+/// pointers and adjusts the reference count of the `Palette`. Now you have the
+/// `Palette`, and _also_ that thing has the same `Palette`. An edit to the
+/// `Palette` data in either location will affect everyone's data. Having a
+/// `&mut Palette` does _not_ mean that you have an exclusive path of access to
+/// the `Palette` contents.
 ///
 /// As a result, I cannot allow you to _ever_ construct a shared reference or
 /// unique reference to the `Color` data held inside the `Palette`. This means
@@ -68,12 +68,11 @@ impl From<Color> for SDL_Color {
 /// This definitely makes the API of the `Palette` type not quite as fun as you
 /// might like.
 ///
-/// You can allocate a `Palette` by calling
-/// [SDLToken::new_palette](SDLToken::new_palette) and specifying how many
-/// `Color` values the `Palette` should hold. However, you generally do not need
-/// to do this yourself, because if a `Surface` or `PixelFormat` needs palette
-/// data it will automatically allocate a palette of the correct size when it is
-/// created.
+/// You can allocate a `Palette` by calling [SDLToken::new_palette] and
+/// specifying how many `Color` values the `Palette` should hold. However, you
+/// generally do not need to do this yourself, because if a `Surface` or
+/// `PixelFormat` needs palette data it will automatically allocate a palette of
+/// the correct size when it is created.
 ///
 /// All slots in a new `Palette` are initialized to opaque white (`0xFF` in all
 /// four color channels).
@@ -85,10 +84,10 @@ pub struct Palette<'sdl> {
 }
 
 impl SDLToken {
-  /// Allocates a new [Palette](Palette) with the number of color slots given.
+  /// Allocates a new [Palette] with the number of color slots given.
   ///
-  /// The initial value of the palette color values is 0xFF in all four channels
-  /// (opaque white).
+  /// The initial value of the palette color values is `0xFF` in all four
+  /// channels (opaque white).
   pub fn new_palette(&self, color_count: usize) -> Result<Palette<'_>, String> {
     let max = core::i32::MAX as usize;
     if color_count > max {
@@ -152,7 +151,7 @@ impl Palette<'_> {
     }
   }
 
-  /// Gets the [Color](Color) at the index specified.
+  /// Gets the [Color] at the index specified.
   ///
   /// ## Failure
   ///
@@ -165,7 +164,7 @@ impl Palette<'_> {
     }
   }
 
-  /// Creates a new [Vec](Vec) with the same colors as this `Palette`.
+  /// Creates a new [Vec] with the same colors as this `Palette`.
   pub fn to_vec(&self) -> Vec<Color> {
     // Note(Lokathor): This is safe only as long as this slice never leaves
     // this function call.

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -2,16 +2,38 @@ use super::*;
 
 /// A palette of [Color](Color) values.
 ///
-/// A `Palette` value is a handle to a heap allocated `SDL_Palette`. That
-/// `SDL_Palette` then has a pointer to the `Color` values, length, and some
-/// reference count and version info. So you can think of it as being _similar
-/// to_ `*mut Rc<[Color]>` or something like that.
-#[derive(Debug)]
+/// The way that the `Palette` type works is very different from Rust's normal
+/// ownership model, so please pay attention as I explain.
+///
+/// A `Palette` value holds a pointer to a heap allocated
+/// [SDL_Palette](SDL_Palette). That `SDL_Palette` has a pointer to the heap
+/// allocated `Color` values, along with a length, reference count, and version
+/// number.
+///
+/// You allocate a `Palette` by calling
+/// [SDLToken::new_palette](SDLToken::new_palette) and specifying how many
+/// `Color` values the `Palette` should hold. All slots in a new `Palette` are
+/// initialized to opaque white (`0xFF` in all four color channel).
+///
+/// When you set a Palette on a [Surface](Surface) or [PixelFormat](PixelFormat)
+/// it moves some pointers and adjusts the reference count of the `Palette`. Now
+/// you have the `Palette`, and _also_ that thing has the same `Palette`. An
+/// edit to the `Palette` data in either location will affect everyone's data.
+///
+/// As a result, I cannot allow you to _ever_ construct a shared reference or
+/// unique reference to the `Color` data held inside the `Palette`. This means
+/// no [Deref](Deref), [Index](Index), or [IndexMut](IndexMut), no Iterators of
+/// any kind, none of that. This definitely makes the API of the `Palette` type
+/// not quite as fun as you might like.
+#[derive(Debug)] // TODO: We probably want a custom Debug impl
 #[repr(transparent)]
 pub struct Palette<'sdl> {
-  pub(crate) ptr: *mut SDL_Palette,
+  pub(crate) ptr: *mut SDL_Palette, // TODO: NonNull<SDL_Palette> ?
   pub(crate) _marker: PhantomData<&'sdl SDLToken>,
 }
+
+// TODO: PAST HERE NEEDS A CAREFUL SECOND PASS VERIFICATION
+
 impl<'sdl> Clone for Palette<'sdl> {
   fn clone(&self) -> Self {
     let ptr = unsafe { SDL_AllocPalette(self.len() as i32) };

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -2,18 +2,20 @@ use super::*;
 
 /// A palette of [Color](Color) values.
 ///
-/// The way that the `Palette` type works is different from Rust's normal
-/// ownership model, so please pay attention as I explain.
+/// The way that the `Palette` type works is slightly different from Rust's
+/// normal ownership model, so please pay attention as I explain.
 ///
 /// A `Palette` value holds a pointer to a heap allocated
 /// [SDL_Palette](SDL_Palette) ([wiki](https://wiki.libsdl.org/SDL_Palette)).
 /// That `SDL_Palette` has a pointer to the heap allocated `Color` values, along
 /// with a length, reference count, and version number.
 ///
-/// When you set a Palette on a [Surface](Surface) or [PixelFormat](PixelFormat)
+/// When you set a `Palette` on a [Surface](Surface) or [PixelFormat](PixelFormat)
 /// it moves some pointers and adjusts the reference count of the `Palette`. Now
 /// you have the `Palette`, and _also_ that thing has the same `Palette`. An
 /// edit to the `Palette` data in either location will affect everyone's data.
+/// Having a `&mut Palette` does _not_ mean that you have an exclusive path of
+/// access to the `Palette` contents.
 ///
 /// As a result, I cannot allow you to _ever_ construct a shared reference or
 /// unique reference to the `Color` data held inside the `Palette`. This means
@@ -34,45 +36,16 @@ use super::*;
 #[derive(Debug)] // TODO: We probably want a custom Debug impl
 #[repr(transparent)]
 pub struct Palette<'sdl> {
-  pub(crate) ptr: *mut SDL_Palette, // TODO: NonNull<SDL_Palette> ?
+  pub(crate) nn: NonNull<SDL_Palette>,
   pub(crate) _marker: PhantomData<&'sdl SDLToken>,
 }
 
-// TODO: PAST HERE NEEDS A CAREFUL SECOND PASS VERIFICATION
-
-impl<'sdl> Clone for Palette<'sdl> {
-  fn clone(&self) -> Self {
-    let ptr = unsafe { SDL_AllocPalette(self.len() as i32) };
-    if ptr.is_null() {
-      panic!("OOM: Could not allocate a new Palette!");
-    } else {
-      let mut n = Palette {
-        ptr,
-        _marker: PhantomData,
-      };
-      let self_slice = unsafe {
-        core::slice::from_raw_parts(
-          (*self.ptr).colors as *mut Color,
-          (*self.ptr).ncolors as usize,
-        )
-      };
-      n.set_colors(0, self_slice)
-        .expect("Failed to copy over the color data!");
-      n
-    }
-  }
-}
-impl<'sdl> Drop for Palette<'sdl> {
-  fn drop(&mut self) {
-    unsafe { SDL_FreePalette(self.ptr) }
-  }
-}
 impl SDLToken {
   /// Allocates a new [Palette](Palette) with the number of color slots given.
   ///
   /// The initial value of the palette color values is 0xFF in all four channels
   /// (opaque white).
-  pub fn new_palette<'sdl>(&'sdl self, color_count: usize) -> Result<Palette<'sdl>, String> {
+  pub fn new_palette(&self, color_count: usize) -> Result<Palette<'_>, String> {
     let max = core::i32::MAX as usize;
     if color_count > max {
       return Err("beryllium error: color_count > i32::MAX".to_string());
@@ -80,63 +53,48 @@ impl SDLToken {
     if color_count < 2 {
       return Err("beryllium error: color_count of a palette must be at least 2".to_string());
     }
-    let ptr = unsafe { SDL_AllocPalette(color_count as i32) };
-    if ptr.is_null() {
-      Err(get_error())
-    } else {
-      Ok(Palette {
-        ptr,
+    match NonNull::new(unsafe { SDL_AllocPalette(color_count as i32) }) {
+      Some(nn) => Ok(Palette {
+        nn,
         _marker: PhantomData,
-      })
+      }),
+      None => Err(get_error()),
     }
   }
 }
 
+impl Drop for Palette<'_> {
+  fn drop(&mut self) {
+    unsafe { SDL_FreePalette(self.nn.as_ptr()) }
+  }
+}
+
 #[allow(clippy::len_without_is_empty)]
-impl<'sdl> Palette<'sdl> {
+impl Palette<'_> {
   /// Gets the number of colors in the Palette
   pub fn len(&self) -> usize {
-    unsafe { (*self.ptr).ncolors as usize }
-  }
-
-  /// Gets the [Color](Color) at the index specified.
-  pub fn get_color(&self, index: usize) -> Option<Color> {
-    if index < self.len() {
-      Some(unsafe { (*(*self.ptr).colors.add(index)).into() })
-    } else {
-      None
-    }
-  }
-
-  /// Assigns the given color to the index specified.
-  ///
-  /// This is shorthand for [set_colors](Palette::set_colors) with a single
-  /// element slice. If you have many colors in a row to set you should use that
-  /// instead.
-  pub fn set_color(&mut self, index: usize, color: Color) -> Result<(), String> {
-    self.set_colors(index, core::slice::from_ref(&color))
+    unsafe { (*self.nn.as_ptr()).ncolors as usize }
   }
 
   /// Assigns a slice of colors into the `Palette`, starting at the position
   /// specified.
   ///
-  /// This seems silly, but SDL2 has a specific routine it uses for altering
-  /// palette colors and we have to go though that, which normal use of the
-  /// `IndexMut` trait would not do.
+  /// Colors that don't "fit" because they would trail off the end are not copied.
   ///
-  /// `start` values >= the length will give an error. The input slice is
-  /// automatically clipped as necessary, so as to not go out of bounds.
-  pub fn set_colors(&mut self, start: usize, new_colors: &[Color]) -> Result<(), String> {
+  /// ## Failure
+  ///
+  /// * `start` values >= the length will give an error.
+  pub fn set_colors(&self, start: usize, new_colors: &[Color]) -> Result<(), String> {
     if start >= self.len() {
       return Err("beryllium error: start index out of bounds".to_string());
     }
-    // We'll manually clip the input slice instead of relying on SDL2's dubious
-    // clipping process.
+    // Note(Lokathor): We'll manually clip the input length instead of relying
+    // on SDL2's dubious clipping process.
     let clipped_length = (self.len() - start).min(new_colors.len());
     debug_assert!(start + clipped_length <= self.len());
     let out = unsafe {
       SDL_SetPaletteColors(
-        self.ptr,
+        self.nn.as_ptr(),
         new_colors.as_ptr() as *const SDL_Color,
         start as i32,
         clipped_length as i32,
@@ -147,6 +105,56 @@ impl<'sdl> Palette<'sdl> {
     } else {
       // Given our previous checks, this path should never happen.
       Err(get_error())
+    }
+  }
+
+  /// Gets the [Color](Color) at the index specified.
+  ///
+  /// ## Failure
+  ///
+  /// * `None` if the index is out of bounds.
+  pub fn get_color(&self, index: usize) -> Option<Color> {
+    if index >= self.len() {
+      None
+    } else {
+      Some(unsafe { (*(*self.nn.as_ptr()).colors.add(index)).into() })
+    }
+  }
+}
+
+impl Clone for Palette<'_> {
+  /// Clones the colors into an entirely distinct `Palette` of the same length.
+  ///
+  /// First a new palette of the same length is allocated, then all colors are
+  /// copied over.
+  ///
+  /// ## Panics
+  ///
+  /// * If the `SDL_Palette` cannot be allocated this will panic. That
+  ///   essentially only happens if you're out of memory.
+  /// * If the colors cannot be copied over this will panic. It should be
+  ///   impossible for that to fail, but hey.
+  fn clone(&self) -> Self {
+    match NonNull::new(unsafe { SDL_AllocPalette(self.len() as i32) }) {
+      Some(nn) => {
+        let out = Self {
+          nn,
+          _marker: PhantomData,
+        };
+        // Note(Lokathor): This is safe because
+        let self_slice = unsafe {
+          core::slice::from_raw_parts(
+            (*self.nn.as_ptr()).colors as *mut Color,
+            (*self.nn.as_ptr()).ncolors as usize,
+          )
+        };
+
+        out
+          .set_colors(0, self_slice)
+          .expect("Failed to copy the color data!");
+        out
+      }
+      None => panic!("OOM: couldn't allocate an SDL_Palette!"),
     }
   }
 }

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -80,7 +80,7 @@ impl<'sdl> Palette<'sdl> {
     }
     // We'll manually clip the input slice instead of relying on SDL2's dubious
     // clipping process.
-    let clipped_length =(self.len() - start).min(new_colors.len());
+    let clipped_length = (self.len() - start).min(new_colors.len());
     debug_assert!(start + clipped_length <= self.len());
     let out = unsafe {
       SDL_SetPaletteColors(

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -1,0 +1,103 @@
+use super::*;
+
+/// A palette of [Color](Color) values.
+///
+/// A `Palette` value is a handle to a heap allocated `SDL_Palette`. That
+/// `SDL_Palette` then has a pointer to the `Color` values, length, and some
+/// reference count and version info. So you can think of it as being _similar
+/// to_ `*mut Rc<[Color]>` or something like that.
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct Palette<'sdl> {
+  pub(crate) ptr: *mut SDL_Palette,
+  pub(crate) _marker: PhantomData<&'sdl SDLToken>,
+}
+impl<'sdl> Clone for Palette<'sdl> {
+  fn clone(&self) -> Self {
+    let mut n =
+      unsafe { Self::new((*self.ptr).ncolors).expect("OOM: Could not allocate a new Palette!") };
+    n.set_colors(0, &self)
+      .expect("Failed to copy over the color data!");
+    n
+  }
+}
+impl<'sdl> Drop for Palette<'sdl> {
+  fn drop(&mut self) {
+    unsafe { SDL_FreePalette(self.ptr) }
+  }
+}
+impl<'sdl> Deref for Palette<'sdl> {
+  type Target = [Color];
+
+  /// We can _read_ the Color values normally, we just can't _write_ the
+  /// `Palette` normally.
+  fn deref(&self) -> &Self::Target {
+    unsafe {
+      core::slice::from_raw_parts(
+        (*self.ptr).colors as *mut Color,
+        (*self.ptr).ncolors as usize,
+      )
+    }
+  }
+}
+impl<'sdl> Palette<'sdl> {
+  /// Allocates a new palette with the number of color slots given.
+  ///
+  /// The initial value of the palette color values is 0xFF in all four channels
+  /// (opaque white).
+  pub fn new(color_count: i32) -> Result<Palette<'sdl>, String> {
+    let ptr = unsafe { SDL_AllocPalette(color_count) };
+    if ptr.is_null() {
+      Err(get_error())
+    } else {
+      Ok(Self {
+        ptr,
+        _marker: PhantomData,
+      })
+    }
+  }
+
+  /// Gets the number of colors in the Palette
+  pub fn len(&self) -> usize {
+    unsafe { (*self.ptr).ncolors as usize }
+  }
+
+  /// Assigns a slice of colors into the `Palette`, starting at the position
+  /// specified.
+  ///
+  /// This seems silly, but SDL2 has a specific routine it uses for altering
+  /// palette colors and we have to go though that, which normal use of the
+  /// `IndexMut` trait would not do.
+  pub fn set_colors(&mut self, start: usize, new_colors: &[Color]) -> Result<(), String> {
+    let max = core::i32::MAX as usize;
+    if start > max {
+      return Err("beryllium error: start index > i32::MAX".to_string());
+    }
+    let len = new_colors.len();
+    if len > max {
+      return Err("beryllium error: slice length > i32::MAX".to_string());
+    }
+    let out = unsafe {
+      SDL_SetPaletteColors(
+        self.ptr,
+        new_colors.as_ptr() as *const SDL_Color,
+        start as i32,
+        new_colors.len() as i32,
+      )
+    };
+    if out == 0 {
+      Ok(())
+    } else {
+      Err(get_error())
+    }
+  }
+
+  /// Assigns the given color to the index specified.
+  ///
+  /// This is shorthand for [set_colors](Palette::set_colors) with a single
+  /// element slice. If you have many colors in a row to set you should use that
+  /// instead.
+  pub fn set_color(&mut self, index: usize, color: Color) -> Result<(), String> {
+    self.set_colors(index, core::slice::from_ref(&color))
+  }
+}

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -80,14 +80,14 @@ impl<'sdl> Palette<'sdl> {
     }
     // We'll manually clip the input slice instead of relying on SDL2's dubious
     // clipping process.
-    let clipped_new_colors = &new_colors[..(self.len() - start).min(new_colors.len())];
-    debug_assert!(start + clipped_new_colors.len() <= self.len());
+    let clipped_length =(self.len() - start).min(new_colors.len());
+    debug_assert!(start + clipped_length <= self.len());
     let out = unsafe {
       SDL_SetPaletteColors(
         self.ptr,
-        clipped_new_colors.as_ptr() as *const SDL_Color,
+        new_colors.as_ptr() as *const SDL_Color,
         start as i32,
-        clipped_new_colors.len() as i32,
+        clipped_length as i32,
       )
     };
     if out == 0 {

--- a/src/pixel_format.rs
+++ b/src/pixel_format.rs
@@ -1,0 +1,366 @@
+use super::*;
+
+/// The various named pixel formats that SDL2 supports.
+///
+/// There's various checks you can perform on each pixel format.
+///
+/// Note that the "fourcc" formats, anything that gives `true` from the
+/// [is_fourcc](PixelFormatEnum::is_fourcc) method, are industry specified special
+/// values, and do not follow SDL2's bit packing scheme. In other words, the
+/// output they produce for any of the other check methods is not to really be
+/// trusted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(windows, repr(i32))]
+#[cfg_attr(not(windows), repr(u32))]
+#[allow(missing_docs)]
+pub enum PixelFormatEnum {
+  Unknown = SDL_PIXELFORMAT_UNKNOWN,
+  Index1lsb = SDL_PIXELFORMAT_INDEX1LSB,
+  Index1msb = SDL_PIXELFORMAT_INDEX1MSB,
+  Index4lsb = SDL_PIXELFORMAT_INDEX4LSB,
+  Index4msb = SDL_PIXELFORMAT_INDEX4MSB,
+  Index8 = SDL_PIXELFORMAT_INDEX8,
+  RGB332 = SDL_PIXELFORMAT_RGB332,
+  RGB444 = SDL_PIXELFORMAT_RGB444,
+  RGB555 = SDL_PIXELFORMAT_RGB555,
+  BGR555 = SDL_PIXELFORMAT_BGR555,
+  ARGB4444 = SDL_PIXELFORMAT_ARGB4444,
+  RGBA4444 = SDL_PIXELFORMAT_RGBA4444,
+  ABGR4444 = SDL_PIXELFORMAT_ABGR4444,
+  BGRA4444 = SDL_PIXELFORMAT_BGRA4444,
+  ARGB1555 = SDL_PIXELFORMAT_ARGB1555,
+  RGBA5551 = SDL_PIXELFORMAT_RGBA5551,
+  ABGR1555 = SDL_PIXELFORMAT_ABGR1555,
+  BGRA5551 = SDL_PIXELFORMAT_BGRA5551,
+  RGB565 = SDL_PIXELFORMAT_RGB565,
+  BGR565 = SDL_PIXELFORMAT_BGR565,
+  RGB24 = SDL_PIXELFORMAT_RGB24,
+  BGR24 = SDL_PIXELFORMAT_BGR24,
+  RGB888 = SDL_PIXELFORMAT_RGB888,
+  RGBX8888 = SDL_PIXELFORMAT_RGBX8888,
+  BGR888 = SDL_PIXELFORMAT_BGR888,
+  BGRX8888 = SDL_PIXELFORMAT_BGRX8888,
+  ARGB8888 = SDL_PIXELFORMAT_ARGB8888,
+  RGBA8888 = SDL_PIXELFORMAT_RGBA8888,
+  ABGR8888 = SDL_PIXELFORMAT_ABGR8888,
+  BGRA8888 = SDL_PIXELFORMAT_BGRA8888,
+  ARGB2101010 = SDL_PIXELFORMAT_ARGB2101010,
+  /// Planar mode: Y + V + U (3 planes)
+  YV12 = SDL_PIXELFORMAT_YV12,
+  /// Planar mode: Y + U + V (3 planes)
+  IYUV = SDL_PIXELFORMAT_IYUV,
+  /// Packed mode: Y0+U0+Y1+V0 (1 plane)
+  YUY2 = SDL_PIXELFORMAT_YUY2,
+  /// Packed mode: U0+Y0+V0+Y1 (1 plane)
+  UYVY = SDL_PIXELFORMAT_UYVY,
+  /// Packed mode: Y0+V0+Y1+U0 (1 plane)
+  YVYU = SDL_PIXELFORMAT_YVYU,
+  /// Planar mode: Y + U/V interleaved (2 planes)
+  NV12 = SDL_PIXELFORMAT_NV12,
+  /// Planar mode: Y + V/U interleaved (2 planes)
+  NV21 = SDL_PIXELFORMAT_NV21,
+  /// Android video texture format
+  ExternalOES = SDL_PIXELFORMAT_EXTERNAL_OES,
+}
+#[cfg(target_endian = "big")]
+impl PixelFormatEnum {
+  /// Platform specific alias for RGBA
+  pub const RGBA32: Self = PixelFormatEnum::RGBA8888;
+  /// Platform specific alias for ARGB
+  pub const ARGB32: Self = PixelFormatEnum::ARGB8888;
+  /// Platform specific alias for BGRA
+  pub const BGRA32: Self = PixelFormatEnum::BGRA8888;
+  /// Platform specific alias for ABGR
+  pub const ABGR32: Self = PixelFormatEnum::ABGR8888;
+}
+#[cfg(target_endian = "little")]
+impl PixelFormatEnum {
+  /// Platform specific alias for RGBA
+  pub const RGBA32: Self = PixelFormatEnum::ABGR8888;
+  /// Platform specific alias for ARGB
+  pub const ARGB32: Self = PixelFormatEnum::BGRA8888;
+  /// Platform specific alias for BGRA
+  pub const BGRA32: Self = PixelFormatEnum::ARGB8888;
+  /// Platform specific alias for ABGR
+  pub const ABGR32: Self = PixelFormatEnum::RGBA8888;
+}
+impl From<fermium::_bindgen_ty_6::Type> for PixelFormatEnum {
+  fn from(pf: fermium::_bindgen_ty_6::Type) -> Self {
+    match pf {
+      SDL_PIXELFORMAT_INDEX1LSB => PixelFormatEnum::Index1lsb,
+      SDL_PIXELFORMAT_INDEX1MSB => PixelFormatEnum::Index1msb,
+      SDL_PIXELFORMAT_INDEX4LSB => PixelFormatEnum::Index4lsb,
+      SDL_PIXELFORMAT_INDEX4MSB => PixelFormatEnum::Index4msb,
+      SDL_PIXELFORMAT_INDEX8 => PixelFormatEnum::Index8,
+      SDL_PIXELFORMAT_RGB332 => PixelFormatEnum::RGB332,
+      SDL_PIXELFORMAT_RGB444 => PixelFormatEnum::RGB444,
+      SDL_PIXELFORMAT_RGB555 => PixelFormatEnum::RGB555,
+      SDL_PIXELFORMAT_BGR555 => PixelFormatEnum::BGR555,
+      SDL_PIXELFORMAT_ARGB4444 => PixelFormatEnum::ARGB4444,
+      SDL_PIXELFORMAT_RGBA4444 => PixelFormatEnum::RGBA4444,
+      SDL_PIXELFORMAT_ABGR4444 => PixelFormatEnum::ABGR4444,
+      SDL_PIXELFORMAT_BGRA4444 => PixelFormatEnum::BGRA4444,
+      SDL_PIXELFORMAT_ARGB1555 => PixelFormatEnum::ARGB1555,
+      SDL_PIXELFORMAT_RGBA5551 => PixelFormatEnum::RGBA5551,
+      SDL_PIXELFORMAT_ABGR1555 => PixelFormatEnum::ABGR1555,
+      SDL_PIXELFORMAT_BGRA5551 => PixelFormatEnum::BGRA5551,
+      SDL_PIXELFORMAT_RGB565 => PixelFormatEnum::RGB565,
+      SDL_PIXELFORMAT_BGR565 => PixelFormatEnum::BGR565,
+      SDL_PIXELFORMAT_RGB24 => PixelFormatEnum::RGB24,
+      SDL_PIXELFORMAT_BGR24 => PixelFormatEnum::BGR24,
+      SDL_PIXELFORMAT_RGB888 => PixelFormatEnum::RGB888,
+      SDL_PIXELFORMAT_RGBX8888 => PixelFormatEnum::RGBX8888,
+      SDL_PIXELFORMAT_BGR888 => PixelFormatEnum::BGR888,
+      SDL_PIXELFORMAT_BGRX8888 => PixelFormatEnum::BGRX8888,
+      SDL_PIXELFORMAT_ARGB8888 => PixelFormatEnum::ARGB8888,
+      SDL_PIXELFORMAT_RGBA8888 => PixelFormatEnum::RGBA8888,
+      SDL_PIXELFORMAT_ABGR8888 => PixelFormatEnum::ABGR8888,
+      SDL_PIXELFORMAT_BGRA8888 => PixelFormatEnum::BGRA8888,
+      SDL_PIXELFORMAT_ARGB2101010 => PixelFormatEnum::ARGB2101010,
+      SDL_PIXELFORMAT_YV12 => PixelFormatEnum::YV12,
+      SDL_PIXELFORMAT_IYUV => PixelFormatEnum::IYUV,
+      SDL_PIXELFORMAT_YUY2 => PixelFormatEnum::YUY2,
+      SDL_PIXELFORMAT_UYVY => PixelFormatEnum::UYVY,
+      SDL_PIXELFORMAT_YVYU => PixelFormatEnum::YVYU,
+      SDL_PIXELFORMAT_NV12 => PixelFormatEnum::NV12,
+      SDL_PIXELFORMAT_NV21 => PixelFormatEnum::NV21,
+      SDL_PIXELFORMAT_EXTERNAL_OES => PixelFormatEnum::ExternalOES,
+      _ => PixelFormatEnum::Unknown,
+    }
+  }
+}
+impl Default for PixelFormatEnum {
+  fn default() -> Self {
+    PixelFormatEnum::Unknown
+  }
+}
+impl PixelFormatEnum {
+  /// The type of the pixel format.
+  ///
+  /// All unknown types convert to `PixelType::Unknown`, of course.
+  pub fn pixel_type(self) -> PixelType {
+    match ((self as u32 >> 24) & 0x0F) as fermium::_bindgen_ty_1::Type {
+      SDL_PIXELTYPE_INDEX1 => PixelType::Index1,
+      SDL_PIXELTYPE_INDEX4 => PixelType::Index4,
+      SDL_PIXELTYPE_INDEX8 => PixelType::Index8,
+      SDL_PIXELTYPE_PACKED8 => PixelType::Packed8,
+      SDL_PIXELTYPE_PACKED16 => PixelType::Packed16,
+      SDL_PIXELTYPE_PACKED32 => PixelType::Packed32,
+      SDL_PIXELTYPE_ARRAYU8 => PixelType::ArrayU8,
+      SDL_PIXELTYPE_ARRAYU16 => PixelType::ArrayU16,
+      SDL_PIXELTYPE_ARRAYU32 => PixelType::ArrayU32,
+      SDL_PIXELTYPE_ARRAYF16 => PixelType::ArrayF16,
+      SDL_PIXELTYPE_ARRAYF32 => PixelType::ArrayF32,
+      _ => PixelType::Unknown,
+    }
+  }
+
+  /// Ordering of channel or bits in the pixel format.
+  ///
+  /// Unknown values convert to one of the `None` variants.
+  pub fn pixel_order(self) -> PixelOrder {
+    let bits = (self as u32 >> 20) & 0x0F;
+    if self.is_packed() {
+      match bits as fermium::_bindgen_ty_4::Type {
+        SDL_PACKEDORDER_ABGR => PixelOrder::Packed(PackedPixelOrder::ABGR),
+        SDL_PACKEDORDER_ARGB => PixelOrder::Packed(PackedPixelOrder::ARGB),
+        SDL_PACKEDORDER_BGRA => PixelOrder::Packed(PackedPixelOrder::BGRA),
+        SDL_PACKEDORDER_BGRX => PixelOrder::Packed(PackedPixelOrder::BGRX),
+        SDL_PACKEDORDER_RGBA => PixelOrder::Packed(PackedPixelOrder::RGBA),
+        SDL_PACKEDORDER_RGBX => PixelOrder::Packed(PackedPixelOrder::RGBX),
+        SDL_PACKEDORDER_XBGR => PixelOrder::Packed(PackedPixelOrder::XBGR),
+        SDL_PACKEDORDER_XRGB => PixelOrder::Packed(PackedPixelOrder::XRGB),
+        _ => PixelOrder::Packed(PackedPixelOrder::None),
+      }
+    } else if self.is_array() {
+      match bits as fermium::_bindgen_ty_4::Type {
+        SDL_ARRAYORDER_ABGR => PixelOrder::Array(ArrayPixelOrder::ABGR),
+        SDL_ARRAYORDER_ARGB => PixelOrder::Array(ArrayPixelOrder::ARGB),
+        SDL_ARRAYORDER_BGR => PixelOrder::Array(ArrayPixelOrder::BGR),
+        SDL_ARRAYORDER_BGRA => PixelOrder::Array(ArrayPixelOrder::BGRA),
+        SDL_ARRAYORDER_RGB => PixelOrder::Array(ArrayPixelOrder::RGB),
+        SDL_ARRAYORDER_RGBA => PixelOrder::Array(ArrayPixelOrder::RGBA),
+        _ => PixelOrder::Array(ArrayPixelOrder::None),
+      }
+    } else {
+      match bits as fermium::_bindgen_ty_2::Type {
+        SDL_BITMAPORDER_1234 => PixelOrder::Bitmap(BitmapPixelOrder::_1234),
+        SDL_BITMAPORDER_4321 => PixelOrder::Bitmap(BitmapPixelOrder::_4321),
+        _ => PixelOrder::Bitmap(BitmapPixelOrder::None),
+      }
+    }
+  }
+
+  /// Channel bits pattern of the pixel format.
+  ///
+  /// Converts any possible unknown layout to `PixelLayout::None`.
+  pub fn pixel_layout(self) -> PixelLayout {
+    match ((self as u32 >> 16) & 0x0F) as fermium::_bindgen_ty_1::Type {
+      SDL_PACKEDLAYOUT_332 => PixelLayout::_332,
+      SDL_PACKEDLAYOUT_4444 => PixelLayout::_4444,
+      SDL_PACKEDLAYOUT_1555 => PixelLayout::_1555,
+      SDL_PACKEDLAYOUT_5551 => PixelLayout::_5551,
+      SDL_PACKEDLAYOUT_565 => PixelLayout::_565,
+      SDL_PACKEDLAYOUT_8888 => PixelLayout::_8888,
+      SDL_PACKEDLAYOUT_2101010 => PixelLayout::_2101010,
+      SDL_PACKEDLAYOUT_1010102 => PixelLayout::_1010102,
+      _ => PixelLayout::None,
+    }
+  }
+
+  /// Bits of color information per pixel.
+  pub fn bits_per_pixel(self) -> u32 {
+    (self as u32 >> 8) & 0xFF
+  }
+
+  /// Bytes used per pixel.
+  ///
+  /// Note: Formats with less than 8 bits per pixel give a result of 0 bytes per
+  /// pixel. Weird and all, but that's how it is.
+  pub fn bytes_per_pixel(self) -> u32 {
+    if self.is_fourcc() {
+      match self {
+        PixelFormatEnum::YUY2 | PixelFormatEnum::UYVY | PixelFormatEnum::YVYU => 2,
+        _ => 1,
+      }
+    } else {
+      self as u32 & 0xFF
+    }
+  }
+
+  /// Is this format an indexed format?
+  pub fn is_indexed(self) -> bool {
+    !self.is_fourcc()
+      && match self.pixel_type() {
+        PixelType::Index1 | PixelType::Index4 | PixelType::Index8 => true,
+        _ => false,
+      }
+  }
+
+  /// Is this format a packed format?
+  pub fn is_packed(self) -> bool {
+    !self.is_fourcc()
+      && match self.pixel_type() {
+        PixelType::Packed8 | PixelType::Packed16 | PixelType::Packed32 => true,
+        _ => false,
+      }
+  }
+
+  /// Is this format a packed format?
+  pub fn is_array(self) -> bool {
+    !self.is_fourcc()
+      && match self.pixel_type() {
+        PixelType::ArrayU8
+        | PixelType::ArrayU16
+        | PixelType::ArrayU32
+        | PixelType::ArrayF16
+        | PixelType::ArrayF32 => true,
+        _ => false,
+      }
+  }
+
+  /// Is this format a format with an alpha channel?
+  pub fn is_alpha(self) -> bool {
+    match self.pixel_order() {
+      PixelOrder::Packed(PackedPixelOrder::ARGB)
+      | PixelOrder::Packed(PackedPixelOrder::RGBA)
+      | PixelOrder::Packed(PackedPixelOrder::ABGR)
+      | PixelOrder::Packed(PackedPixelOrder::BGRA)
+      | PixelOrder::Array(ArrayPixelOrder::ARGB)
+      | PixelOrder::Array(ArrayPixelOrder::RGBA)
+      | PixelOrder::Array(ArrayPixelOrder::ABGR)
+      | PixelOrder::Array(ArrayPixelOrder::BGRA) => true,
+      _ => false,
+    }
+  }
+
+  /// Is this a [four-character code](https://en.wikipedia.org/wiki/FourCC) format?
+  ///
+  /// True for pixel formats representing unique formats, for example YUV formats.
+  pub fn is_fourcc(self) -> bool {
+    (self as u32 > 0) && (((self as u32 >> 28) & 0x0F) != 1)
+  }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(windows, repr(i32))]
+#[cfg_attr(not(windows), repr(u32))]
+#[allow(missing_docs)]
+pub enum PixelType {
+  Unknown = SDL_PIXELTYPE_UNKNOWN,
+  Index1 = SDL_PIXELTYPE_INDEX1,
+  Index4 = SDL_PIXELTYPE_INDEX4,
+  Index8 = SDL_PIXELTYPE_INDEX8,
+  Packed8 = SDL_PIXELTYPE_PACKED8,
+  Packed16 = SDL_PIXELTYPE_PACKED16,
+  Packed32 = SDL_PIXELTYPE_PACKED32,
+  ArrayU8 = SDL_PIXELTYPE_ARRAYU8,
+  ArrayU16 = SDL_PIXELTYPE_ARRAYU16,
+  ArrayU32 = SDL_PIXELTYPE_ARRAYU32,
+  ArrayF16 = SDL_PIXELTYPE_ARRAYF16,
+  ArrayF32 = SDL_PIXELTYPE_ARRAYF32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub enum PixelOrder {
+  Bitmap(BitmapPixelOrder),
+  Packed(PackedPixelOrder),
+  Array(ArrayPixelOrder),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(windows, repr(i32))]
+#[cfg_attr(not(windows), repr(u32))]
+#[allow(missing_docs)]
+pub enum BitmapPixelOrder {
+  None = SDL_BITMAPORDER_NONE,
+  _4321 = SDL_BITMAPORDER_4321,
+  _1234 = SDL_BITMAPORDER_1234,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(windows, repr(i32))]
+#[cfg_attr(not(windows), repr(u32))]
+#[allow(missing_docs)]
+pub enum PackedPixelOrder {
+  None = SDL_PACKEDORDER_NONE,
+  XRGB = SDL_PACKEDORDER_XRGB,
+  RGBX = SDL_PACKEDORDER_RGBX,
+  ARGB = SDL_PACKEDORDER_ARGB,
+  RGBA = SDL_PACKEDORDER_RGBA,
+  XBGR = SDL_PACKEDORDER_XBGR,
+  BGRX = SDL_PACKEDORDER_BGRX,
+  ABGR = SDL_PACKEDORDER_ABGR,
+  BGRA = SDL_PACKEDORDER_BGRA,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(windows, repr(i32))]
+#[cfg_attr(not(windows), repr(u32))]
+#[allow(missing_docs)]
+pub enum ArrayPixelOrder {
+  None = SDL_ARRAYORDER_NONE,
+  RGB = SDL_ARRAYORDER_RGB,
+  RGBA = SDL_ARRAYORDER_RGBA,
+  ARGB = SDL_ARRAYORDER_ARGB,
+  BGR = SDL_ARRAYORDER_BGR,
+  BGRA = SDL_ARRAYORDER_BGRA,
+  ABGR = SDL_ARRAYORDER_ABGR,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(windows, repr(i32))]
+#[cfg_attr(not(windows), repr(u32))]
+#[allow(missing_docs)]
+pub enum PixelLayout {
+  None = SDL_PACKEDLAYOUT_NONE,
+  _332 = SDL_PACKEDLAYOUT_332,
+  _4444 = SDL_PACKEDLAYOUT_4444,
+  _1555 = SDL_PACKEDLAYOUT_1555,
+  _5551 = SDL_PACKEDLAYOUT_5551,
+  _565 = SDL_PACKEDLAYOUT_565,
+  _8888 = SDL_PACKEDLAYOUT_8888,
+  _2101010 = SDL_PACKEDLAYOUT_2101010,
+  _1010102 = SDL_PACKEDLAYOUT_1010102,
+}

--- a/src/pixel_format.rs
+++ b/src/pixel_format.rs
@@ -142,7 +142,7 @@ impl PixelFormatEnum {
   }
 
   /// Converts this value into the appropriate `bpp` and mask values.
-  pub fn to_masks(&self) -> (i32, u32, u32, u32, u32) {
+  pub fn to_masks(self) -> (i32, u32, u32, u32, u32) {
     let mut bpp = 0;
     let mut r_mask = 0;
     let mut g_mask = 0;
@@ -150,7 +150,7 @@ impl PixelFormatEnum {
     let mut a_mask = 0;
     unsafe {
       SDL_PixelFormatEnumToMasks(
-        (*self) as u32,
+        self as u32,
         &mut bpp,
         &mut r_mask,
         &mut g_mask,

--- a/src/pixel_format.rs
+++ b/src/pixel_format.rs
@@ -553,19 +553,3 @@ impl PixelFormat<'_> {
     unsafe { (*self.nn.as_ptr()).Amask }
   }
 }
-
-impl Clone for PixelFormat<'_> {
-  fn clone(&self) -> Self {
-    match NonNull::new(unsafe { SDL_AllocFormat((*self.nn.as_ptr()).format) }) {
-      Some(nn) => {
-        let other = Self {
-          nn,
-          _marker: PhantomData,
-        };
-        self.palette().map(|pal_ref| other.set_palette(pal_ref));
-        other
-      }
-      None => panic!("OOM: Couldn't allocate a new SDL_PixelFormat!"),
-    }
-  }
-}

--- a/src/pixel_format.rs
+++ b/src/pixel_format.rs
@@ -494,7 +494,7 @@ impl<'sdl> PixelFormat<'sdl> {
 
   /// Reassigns the [Palette](Palette) for this `PixelFormat`
   pub fn set_palette(&mut self, palette: &Palette) -> Result<(), String> {
-    let out = unsafe { SDL_SetPixelFormatPalette(self.ptr, palette.ptr) };
+    let out = unsafe { SDL_SetPixelFormatPalette(self.ptr, palette.nn.as_ptr()) };
     if out == 0 {
       Ok(())
     } else {

--- a/src/pixel_format.rs
+++ b/src/pixel_format.rs
@@ -518,7 +518,9 @@ impl PixelFormat<'_> {
     unsafe {
       match NonNull::new((*self.nn.as_ptr()).palette) {
         // Note(Lokathor): Hey can't you use map here? Naw, the lifetimes get weird.
-        Some(nn) => Some(core::mem::transmute::<&NonNull<SDL_Palette>, &Palette>(&nn)),
+        Some(nn) => Some(
+          &*(&nn as *const std::ptr::NonNull<fermium::SDL_Palette> as *const palette::Palette<'_>),
+        ),
         None => None,
       }
     }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -147,23 +147,4 @@ impl<'sdl> Surface<'sdl> {
       None => SDL_TRUE == unsafe { SDL_SetClipRect(self.ptr, null()) },
     }
   }
-
-  /// The Surface's palette, if any.
-  pub fn palette(&self) -> Option<&Palette> {
-    unsafe {
-      let format_ptr: *mut SDL_PixelFormat = (*self.ptr).format;
-      if format_ptr.is_null() {
-        None
-      } else {
-        let sdl_palette_ptr: *mut SDL_Palette = (*format_ptr).palette;
-        if sdl_palette_ptr.is_null() {
-          None
-        } else {
-          Some(core::mem::transmute::<&*mut SDL_Palette, &Palette<'sdl>>(
-            &sdl_palette_ptr,
-          ))
-        }
-      }
-    }
-  }
 }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -94,9 +94,7 @@ impl<'sdl> Surface<'sdl> {
   /// * You have to follow standard 2D raw pixel editing rules.
   ///   * `y * pitch + x * size_of::<PixelType>()`
   ///   * Stay in bounds and all that jazz
-  pub unsafe fn lock_edit<'surface, F: FnMut(*mut u8)>(
-    &'surface mut self, mut op: F,
-  ) -> Result<(), String> {
+  pub unsafe fn lock_edit<F: FnMut(*mut u8)>(&mut self, mut op: F) -> Result<(), String> {
     let lock_output = SDL_LockSurface(self.ptr);
     if lock_output == 0 {
       op((*self.ptr).pixels as *mut u8);
@@ -120,5 +118,53 @@ impl<'sdl> Surface<'sdl> {
   /// Pitch in **bytes**
   pub fn pitch(&self) -> i32 {
     unsafe { (*self.ptr).pitch }
+  }
+
+  /// The current clipping rectangle for blits.
+  pub fn clip_rect(&self) -> Rect {
+    let mut rect = SDL_Rect::default();
+    unsafe { SDL_GetClipRect(self.ptr, &mut rect) };
+    rect.into()
+  }
+
+  /// Assigns a new clipping rectangle.
+  ///
+  /// * `Some(rect)` will clip blits to be within that rect only.
+  /// * `None` will disable clipping.
+  ///
+  /// Returns `true` if the given rectangle intersects at least part of the
+  /// `Surface` (or if it was `None`). Otherwise you get `false` and all blits
+  /// will be completely clipped.
+  ///
+  /// Either way, blits are clipped to be within bounds of the `Surface`, so you
+  /// don't have to worry about that.
+  pub fn set_clip_rect(&mut self, opt_rect: Option<Rect>) -> bool {
+    match opt_rect {
+      Some(rect) => {
+        let r: SDL_Rect = rect.into();
+        SDL_TRUE == unsafe { SDL_SetClipRect(self.ptr, &r) }
+      }
+      None => SDL_TRUE == unsafe { SDL_SetClipRect(self.ptr, null()) },
+    }
+  }
+
+  /// The Surface's palette, if any.
+  pub fn palette(&self) -> Option<&Palette> {
+    unsafe {
+      let format_ptr: *mut SDL_PixelFormat = (*self.ptr).format;
+      if format_ptr.is_null() {
+        None
+      } else {
+        let sdl_palette_ptr: *mut SDL_Palette = (*format_ptr).palette;
+        if sdl_palette_ptr.is_null() {
+          None
+        } else {
+          let ref_to_palette_ptr: &*mut SDL_Palette = &sdl_palette_ptr;
+          Some(core::mem::transmute::<&*mut SDL_Palette, &Palette<'sdl>>(
+            ref_to_palette_ptr,
+          ))
+        }
+      }
+    }
   }
 }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -159,9 +159,8 @@ impl<'sdl> Surface<'sdl> {
         if sdl_palette_ptr.is_null() {
           None
         } else {
-          let ref_to_palette_ptr: &*mut SDL_Palette = &sdl_palette_ptr;
           Some(core::mem::transmute::<&*mut SDL_Palette, &Palette<'sdl>>(
-            ref_to_palette_ptr,
+            &sdl_palette_ptr,
           ))
         }
       }


### PR DESCRIPTION
Non-Example TODOs:
* [x] doc Palette
* [x] impl Palette
* [ ] test Palette
* [x] doc PixelFormat
* [x] impl PixelFormat, (closes https://github.com/Lokathor/beryllium/issues/48), (closes https://github.com/Lokathor/beryllium/issues/44), (closes https://github.com/Lokathor/beryllium/issues/37), (closes https://github.com/Lokathor/beryllium/issues/45), (closes https://github.com/Lokathor/beryllium/issues/46)
* [ ] test PixelFormat
* [x] Clippy kills the build, (closes https://github.com/Lokathor/beryllium/issues/47)
* [x] Surface stuff with Palette and PixelFormat, (closes https://github.com/Lokathor/beryllium/issues/45)

Example List:
* [x] gl, (closes https://github.com/Lokathor/beryllium/issues/1)
* [x] glium, (closes https://github.com/Lokathor/beryllium/issues/6), (closes https://github.com/Lokathor/beryllium/issues/39)

(closes https://github.com/Lokathor/beryllium/issues/25), either now or in some past commit where I forgot to update the issue.