### PR TITLE
Add support for window events and GL context flags constants.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,8 +85,8 @@ use core::{
 use fermium::{
   SDL_EventType::*, SDL_GLattr::*, SDL_GLprofile::*, SDL_GameControllerAxis::*,
   SDL_GameControllerButton::*, SDL_Keymod::*, SDL_RendererFlags::*, SDL_Scancode::*,
-  SDL_WindowFlags::*, SDL_bool::*, _bindgen_ty_1::*, _bindgen_ty_2::*, _bindgen_ty_3::*,
-  _bindgen_ty_4::*, _bindgen_ty_5::*, _bindgen_ty_6::*, _bindgen_ty_7::*, *,
+  SDL_WindowEventID::*, SDL_WindowFlags::*, SDL_bool::*, _bindgen_ty_1::*, _bindgen_ty_2::*,
+  _bindgen_ty_3::*, _bindgen_ty_4::*, _bindgen_ty_5::*, _bindgen_ty_6::*, _bindgen_ty_7::*, *,
 };
 
 use libc::c_char;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,10 +83,11 @@ use core::{
   slice::from_raw_parts,
 };
 use fermium::{
-  SDL_EventType::*, SDL_GLattr::*, SDL_GLprofile::*, SDL_GameControllerAxis::*,
-  SDL_GameControllerButton::*, SDL_Keymod::*, SDL_RendererFlags::*, SDL_Scancode::*,
-  SDL_WindowEventID::*, SDL_WindowFlags::*, SDL_bool::*, _bindgen_ty_1::*, _bindgen_ty_2::*,
-  _bindgen_ty_3::*, _bindgen_ty_4::*, _bindgen_ty_5::*, _bindgen_ty_6::*, _bindgen_ty_7::*, *,
+  SDL_EventType::*, SDL_GLattr::*, SDL_GLcontextFlag::*, SDL_GLprofile::*,
+  SDL_GameControllerAxis::*, SDL_GameControllerButton::*, SDL_Keymod::*, SDL_RendererFlags::*,
+  SDL_Scancode::*, SDL_WindowEventID::*, SDL_WindowFlags::*, SDL_bool::*, _bindgen_ty_1::*,
+  _bindgen_ty_2::*, _bindgen_ty_3::*, _bindgen_ty_4::*, _bindgen_ty_5::*, _bindgen_ty_6::*,
+  _bindgen_ty_7::*, *,
 };
 
 use libc::c_char;

--- a/src/opengl.rs
+++ b/src/opengl.rs
@@ -85,6 +85,53 @@ pub const CONTEXT_PROFILE_CORE: i32 = SDL_GL_CONTEXT_PROFILE_CORE as i32;
 /// Requests an OpenGL ES context.
 pub const CONTEXT_PROFILE_ES: i32 = SDL_GL_CONTEXT_PROFILE_ES as i32;
 
+/// A flag for use with [`GLattr::ContextFlags`].
+///
+/// This flag maps to `GLX_CONTEXT_DEBUG_BIT_ARB` in the
+/// `GLX_ARB_create_context` extension for X11 and `WGL_CONTEXT_DEBUG_BIT_ARB`
+/// in the `WGL_ARB_create_context` extension for Windows. This flag is
+/// currently ignored on other targets that don't support equivalent
+/// functionality. This flag is intended to put the GL into a "debug" mode which
+/// might offer better developer insights, possibly at a loss of performance
+/// (although a given GL implementation may or may not do anything differently
+/// in the presence of this flag).
+pub const CONTEXT_DEBUG_FLAG: i32 = SDL_GL_CONTEXT_DEBUG_FLAG as i32;
+
+/// A flag for use with [`GLattr::ContextFlags`].
+///
+/// This flag maps to `GLX_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB` in the
+/// `GLX_ARB_create_context` extension for X11 and
+/// `WGL_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB` in the `WGL_ARB_create_context`
+/// extension for Windows. This flag is currently ignored on other targets that
+/// don't support equivalent functionality. This flag is intended to put the GL
+/// into a "forward compatible" mode, which means that no deprecated
+/// functionality will be supported, possibly at a gain in performance, and only
+/// applies to GL 3.0 and later contexts.
+pub const CONTEXT_FORWARD_COMPATIBLE_FLAG: i32 = SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG as i32;
+
+/// A flag for use with [`GLattr::ContextFlags`].
+///
+/// This flag maps to `GLX_CONTEXT_ROBUST_ACCESS_BIT_ARB` in the
+/// `GLX_ARB_create_context_robustness` extension for X11 and
+/// `WGL_CONTEXT_ROBUST_ACCESS_BIT_ARB` in the `WGL_ARB_create_context_robustness`
+/// extension for Windows. This flag is currently ignored on other targets that
+/// don't support equivalent functionality. This flag is intended to require a
+/// GL context that supports the GL_ARB_robustness extension--a mode that offers
+/// a few APIs that are safer than the usual defaults (think `snprintf()` vs
+/// `sprintf()`).
+pub const CONTEXT_ROBUST_ACCESS_FLAG: i32 = SDL_GL_CONTEXT_ROBUST_ACCESS_FLAG as i32;
+
+/// A flag for use with [`GLattr::ContextFlags`].
+///
+/// This flag maps to `GLX_CONTEXT_RESET_ISOLATION_BIT_ARB` in the
+/// `GLX_ARB_robustness_isolation` extension for X11 and
+/// `WGL_CONTEXT_RESET_ISOLATION_BIT_ARB` in the `WGL_ARB_robustness_isolation`
+/// extension for Windows. This flag is currently ignored on other targets that
+/// don't support equivalent functionality. This flag is intended to require the
+/// GL to make promises about what to do in the face of driver or hardware
+/// failure.
+pub const CONTEXT_RESET_ISOLATION_FLAG: i32 = SDL_GL_CONTEXT_RESET_ISOLATION_FLAG as i32;
+
 /// Handle for an OpenGL context.
 ///
 /// # General Safety


### PR DESCRIPTION
The context flags are easy and trivial, so the rest of this PR message is just about the window events (which is still pretty simple, but whatever).

I've tested these manually and they seem to work on macOS (and I have no reason to believe that the OS matters here).

I opted to inline the window events in the event structure to make it less of a pain to match on -- additional nesting would either force a nested match, or make for very pattern parts of `match` arms. (This was something I disliked about `winit` when I used it)

That said I don't really care, so I won't argue if you'd rather a they use a separate enumeration.

I've kept the names close to the SDL names except for `SDL_WINDOWEVENT_EXPOSED` which really has nothing to do with the window being exposed or not.

I skipped `SDL_WINDOWEVENT_TAKE_FOCUS` and `SDL_WINDOWEVENT_HIT_TEST` because they refer to functionality that we don't expose. I think that it's more sensible to add these if/when beryllium adds support for `SDL_SetWindowInputFocus` and/or `SDL_HitTest` APIs. Adding them now seems only likely to confuse. I'm open to changing this too if you'd prefer, but really these APIs seem very niche and I would not be surprised if nobody missed them.