### PR TITLE
Store window in the context, allow the window to be upgraded into a c…

### DIFF
--- a/examples/extern_crate_gl.rs
+++ b/examples/extern_crate_gl.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), String> {
   sdl.gl_set_attribute(GLattr::ContextProfileMask, CONTEXT_PROFILE_CORE);
   sdl.gl_set_attribute(GLattr::ContextMajorVersion, 3);
   sdl.gl_set_attribute(GLattr::ContextMinorVersion, 3);
-  let _ctx = unsafe { window.gl_create_context()? };
+  let window = unsafe { window.try_into_gl()? };
 
   // ONCE WE HAVE A CONTEXT (not before!) we can load up the OpenGL functions
   gl::load_with(|s| unsafe { sdl.gl_get_proc_address(s) });
@@ -47,7 +47,7 @@ fn main() -> Result<(), String> {
     // clear the screen over and over.
     unsafe {
       gl::Clear(gl::COLOR_BUFFER_BIT);
-      window.gl_swap_window();
+      window.swap_window();
     };
   }
 

--- a/examples/extern_crate_glium.rs
+++ b/examples/extern_crate_glium.rs
@@ -62,31 +62,8 @@ fn main() -> Result<(), String> {
 // HERE BEGINS ALL THE LINK UP CODE TO CONNECT GLIUM AND BERYLLIUM
 
 /// This holds the backend parts that beryllium gives you.
-///
-/// We keep them in their raw form and keep a phantom link to the SDLToken
-/// because it makes the whole lifetime thing a lot easier to deal with.
 pub struct BerylliumBackend<'sdl> {
-  win_ptr: *mut beryllium::unsafe_raw_ffi::SDL_Window,
-  ctx: beryllium::unsafe_raw_ffi::SDL_GLContext,
-  _marker: PhantomData<&'sdl SDLToken>,
-}
-
-impl Drop for BerylliumBackend<'_> {
-  /// Because the backend parts are held in raw form, we have to manually,
-  /// carefully transmute them back to their "wrapped" form so that they can
-  /// perform their normal drop.
-  ///
-  /// Note: ManuallyDrop wouldn't improve things here, since the point of using
-  /// the raw forms is to fake out the lifetime system.
-  fn drop(&mut self) {
-    unsafe {
-      // We must drop the context first so it doesn't outlive the window.
-      let context: GLContext = core::mem::transmute(self.ctx);
-      drop(context);
-      let window: Window = core::mem::transmute(self.win_ptr);
-      drop(window);
-    }
-  }
+  window: GLWindow<'sdl>,
 }
 
 impl<'sdl> BerylliumBackend<'sdl> {
@@ -96,28 +73,9 @@ impl<'sdl> BerylliumBackend<'sdl> {
   /// correct context is created.
   pub fn from_window(window: Window<'sdl>) -> Result<Self, String> {
     unsafe {
-      let context: GLContext = window.gl_create_context()?;
-      let ctx: beryllium::unsafe_raw_ffi::SDL_GLContext = core::mem::transmute(context);
-      let win_ptr: *mut beryllium::unsafe_raw_ffi::SDL_Window = core::mem::transmute(window);
       Ok(Self {
-        win_ptr,
-        ctx,
-        _marker: PhantomData,
+        window: window.try_into_gl()?,
       })
-    }
-  }
-
-  /// Reference to the held Window.
-  pub fn window(&self) -> &Window<'sdl> {
-    let r: &*mut beryllium::unsafe_raw_ffi::SDL_Window = &self.win_ptr;
-    unsafe { &*(r as *const *mut beryllium::unsafe_raw_ffi::SDL_Window as *const Window<'sdl>) }
-  }
-
-  /// Reference to the held GLContext
-  pub fn context(&self) -> &GLContext<'sdl, 'sdl> {
-    let r: &beryllium::unsafe_raw_ffi::SDL_GLContext = &self.ctx;
-    unsafe {
-      &*(r as *const beryllium::unsafe_raw_ffi::SDL_GLContext as *const GLContext<'sdl, 'sdl>)
     }
   }
 }
@@ -128,26 +86,30 @@ unsafe impl Backend for BerylliumBackend<'_> {
   fn swap_buffers(&self) -> Result<(), SwapBuffersError> {
     // Note: this can't return error messages to us, so we can't pass any error
     // messages to the caller. Good luck!
-    unsafe { self.window().gl_swap_window() };
+    unsafe { self.window.swap_window() };
     Ok(())
   }
+
   unsafe fn get_proc_address(&self, symbol: &str) -> *const c_void {
     // Note: We can make up a &SDLToken "out of nowhere" because if this window
     // exists then naturally SDL2 is currently initialized. We choose a
     // reference instead of an owned value so that we don't drop the token.
     (&*(&() as *const () as *const beryllium::SDLToken)).gl_get_proc_address(symbol)
   }
+
   fn get_framebuffer_dimensions(&self) -> (u32, u32) {
-    let (w, h) = self.window().gl_get_drawable_size();
+    let (w, h) = self.window.drawable_size();
     (w as u32, h as u32)
   }
+
   fn is_current(&self) -> bool {
-    self.context().is_current()
+    self.window.is_current()
   }
+
   unsafe fn make_current(&self) {
     self
-      .window()
-      .gl_make_current(self.context())
+      .window
+      .make_current()
       .expect("Could not make the context current!")
   }
 }
@@ -172,7 +134,7 @@ impl Facade for BerylliumFacade<'_> {
 impl<'sdl> BerylliumFacade<'sdl> {
   /// Reference to the deeply wrapped Window.
   pub fn window(&self) -> &Window {
-    self.backend.window()
+    &*self.backend.window
   }
 
   /// Starts a new draw frame.

--- a/examples/surface_editing.rs
+++ b/examples/surface_editing.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), String> {
   // Renderer that's easy to do. If you make more than one it's up to you to
   // keep it straight.
   let renderer = unsafe {
-    window.create_renderer(
+    window.try_into_renderer(
       None,
       RendererFlags::default()
         .with_accelerated(true)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ use core::{
   convert::TryFrom,
   ffi::c_void,
   marker::PhantomData,
+  ops::Deref,
   ptr::{null, null_mut, NonNull},
   slice::from_raw_parts,
   sync::atomic::{AtomicBool, Ordering},

--- a/src/opengl.rs
+++ b/src/opengl.rs
@@ -60,7 +60,7 @@ pub enum GLattr {
   /// OpenGL context minor version
   ContextMinorVersion = SDL_GL_CONTEXT_MINOR_VERSION,
 
-  /// some combination of 0 or more of elements of the SDL_GLcontextFlag enumeration; defaults to 0
+  /// some combination of 0 or more of elements of the SDL_GLWindowFlag enumeration; defaults to 0
   ContextFlags = SDL_GL_CONTEXT_FLAGS,
 
   /// type of GL context (Core, Compatibility, ES), default value depends on platform
@@ -138,17 +138,23 @@ pub const CONTEXT_RESET_ISOLATION_FLAG: i32 = SDL_GL_CONTEXT_RESET_ISOLATION_FLA
 ///
 /// The context must be current when you call any method here.
 #[derive(Debug)]
-#[repr(transparent)]
-pub struct GLContext<'sdl, 'win> {
+pub struct GLWindow<'sdl> {
   pub(crate) ctx: SDL_GLContext,
-  pub(crate) _marker: PhantomData<&'win Window<'sdl>>,
+  pub(crate) window: Window<'sdl>,
 }
-impl<'sdl, 'win> Drop for GLContext<'sdl, 'win> {
+impl<'sdl> Drop for GLWindow<'sdl> {
   fn drop(&mut self) {
     unsafe { SDL_GL_DeleteContext(self.ctx) }
   }
 }
-impl<'sdl, 'win> GLContext<'sdl, 'win> {
+impl<'sdl> Deref for GLWindow<'sdl> {
+  type Target = Window<'sdl>;
+
+  fn deref(&self) -> &Self::Target {
+    &self.window
+  }
+}
+impl<'sdl> GLWindow<'sdl> {
   /// Checks if the given extension is available in this context.
   pub unsafe fn extension_supported(&self, name: &str) -> bool {
     let name_null: Vec<u8> = name.bytes().chain(Some(0)).collect();
@@ -183,7 +189,7 @@ impl<'sdl, 'win> GLContext<'sdl, 'win> {
 
   /// Attempts to set the swap interval value.
   ///
-  /// The values work as per [swap_interval](GLContext::swap_interval).
+  /// The values work as per [swap_interval](GLWindow::swap_interval).
   ///
   /// Note that if you request adaptive vsync and get an error it is likely that
   /// standard vsync might still be available as a fallback.
@@ -200,5 +206,35 @@ impl<'sdl, 'win> GLContext<'sdl, 'win> {
   pub fn is_current(&self) -> bool {
     let cur = unsafe { SDL_GL_GetCurrentContext() };
     self.ctx == cur
+  }
+
+  /// Obtains the size of the drawable space in the window.
+  ///
+  /// This gives you a number of "physical pixels", so it might be different
+  /// from the "logical pixels" value you get when you call
+  /// [size](Window::size). This is primarily for use with
+  /// [glViewport](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glViewport.xhtml)
+  pub fn drawable_size(&self) -> (i32, i32) {
+    let mut w = 0;
+    let mut h = 0;
+    unsafe { SDL_GL_GetDrawableSize(self.window.ptr, &mut w, &mut h) };
+    (w, h)
+  }
+
+  /// Swaps the window's OpenGL buffers.
+  ///
+  /// If double buffering isn't enabled this just does nothing.
+  pub unsafe fn swap_window(&self) {
+    SDL_GL_SwapWindow(self.window.ptr)
+  }
+
+  /// Makes the given context the current context in this window.
+  pub unsafe fn make_current(&self) -> Result<(), String> {
+    let out = SDL_GL_MakeCurrent(self.window.ptr, self.ctx);
+    if out == 0 {
+      Ok(())
+    } else {
+      Err(get_error())
+    }
   }
 }

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -6,11 +6,11 @@ use super::*;
 /// display it in the Window.
 #[derive(Debug)]
 #[repr(transparent)]
-pub struct Texture<'sdl, 'win, 'ren> {
+pub struct Texture<'sdl, 'ren> {
   pub(crate) ptr: *mut SDL_Texture,
-  pub(crate) _marker: PhantomData<&'ren Renderer<'sdl, 'win>>,
+  pub(crate) _marker: PhantomData<&'ren RendererWindow<'sdl>>,
 }
-impl<'sdl, 'win, 'ren> Drop for Texture<'sdl, 'win, 'ren> {
+impl<'sdl, 'ren> Drop for Texture<'sdl, 'ren> {
   fn drop(&mut self) {
     unsafe { SDL_DestroyTexture(self.ptr) }
   }

--- a/src/window.rs
+++ b/src/window.rs
@@ -199,10 +199,7 @@ impl<'sdl> Window<'sdl> {
     if ctx.is_null() {
       Err(get_error())
     } else {
-      Ok(GLWindow {
-        ctx: ctx,
-        window: self,
-      })
+      Ok(GLWindow { ctx, window: self })
     }
   }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -96,30 +96,6 @@ impl<'sdl> Window<'sdl> {
     }
   }
 
-  /// Makes a renderer for the window.
-  ///
-  /// # Safety
-  ///
-  /// * Each renderer must only be used with its own window
-  /// * Each renderer must only be used with textures that it created
-  ///
-  /// If you only have a single renderer then this is trivially proved, if you
-  /// make more than one renderer it's up to you to verify this.
-  pub unsafe fn create_renderer<'win>(
-    &'win self, driver_index: Option<usize>, flags: RendererFlags,
-  ) -> Result<Renderer<'sdl, 'win>, String> {
-    let index = driver_index.map(|u| u as i32).unwrap_or(-1);
-    let ptr = SDL_CreateRenderer(self.ptr, index, flags.0 as u32);
-    if ptr.is_null() {
-      Err(get_error())
-    } else {
-      Ok(Renderer {
-        ptr,
-        _marker: PhantomData,
-      })
-    }
-  }
-
   /// Sets the title of the window.
   pub fn set_title(&self, title: &str) {
     let title_null: Vec<u8> = title.bytes().chain(Some(0)).collect();
@@ -196,46 +172,37 @@ impl<'sdl> Window<'sdl> {
     }
   }
 
+  /// Makes a renderer for the window.
+  ///
+  /// # Safety
+  ///
+  /// * Each renderer must only be used with its own window
+  /// * Each renderer must only be used with textures that it created
+  ///
+  /// If you only have a single renderer then this is trivially proved, if you
+  /// make more than one renderer it's up to you to verify this.
+  pub unsafe fn try_into_renderer(
+    self, driver_index: Option<usize>, flags: RendererFlags,
+  ) -> Result<RendererWindow<'sdl>, String> {
+    let index = driver_index.map(|u| u as i32).unwrap_or(-1);
+    let ptr = SDL_CreateRenderer(self.ptr, index, flags.0 as u32);
+    if ptr.is_null() {
+      Err(get_error())
+    } else {
+      Ok(RendererWindow { ptr, window: self })
+    }
+  }
+
   /// Creates a context for this window and makes it current.
-  pub unsafe fn gl_create_context<'win>(&'win self) -> Result<GLContext<'sdl, 'win>, String> {
+  pub unsafe fn try_into_gl(self) -> Result<GLWindow<'sdl>, String> {
     let ctx = SDL_GL_CreateContext(self.ptr);
     if ctx.is_null() {
       Err(get_error())
     } else {
-      Ok(GLContext {
-        ctx,
-        _marker: PhantomData,
+      Ok(GLWindow {
+        ctx: ctx,
+        window: self,
       })
-    }
-  }
-
-  /// Obtains the size of the drawable space in the window.
-  ///
-  /// This gives you a number of "physical pixels", so it might be different
-  /// from the "logical pixels" value you get when you call
-  /// [size](Window::size). This is primarily for use with
-  /// [glViewport](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glViewport.xhtml)
-  pub fn gl_get_drawable_size(&self) -> (i32, i32) {
-    let mut w = 0;
-    let mut h = 0;
-    unsafe { SDL_GL_GetDrawableSize(self.ptr, &mut w, &mut h) };
-    (w, h)
-  }
-
-  /// Swaps the window's OpenGL buffers.
-  ///
-  /// If double buffering isn't enabled this just does nothing.
-  pub unsafe fn gl_swap_window(&self) {
-    SDL_GL_SwapWindow(self.ptr)
-  }
-
-  /// Makes the given context the current context in this window.
-  pub unsafe fn gl_make_current(&self, ctx: &GLContext) -> Result<(), String> {
-    let out = SDL_GL_MakeCurrent(self.ptr, ctx.ctx);
-    if out == 0 {
-      Ok(())
-    } else {
-      Err(get_error())
     }
   }
 }


### PR DESCRIPTION
Store window in the context, rename the context types to ContextName+Window, allow the window to be upgraded into a context.

Renderer -> RendererWindow
GLContext -> GLWindow

Related issue: https://github.com/Lokathor/beryllium/issues/76