### PR TITLE
Make init safe by checking the current thread on macos/ios

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ fermium = "0.0.15"
 phantom-fields = "^0.1.2"
 libc = "0.2"
 
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+objc = "0.2.6"
+
 [dev-dependencies]
 gl = "0.12"
 glium = "0.25"

--- a/examples/audio_queue_tone.rs
+++ b/examples/audio_queue_tone.rs
@@ -3,7 +3,7 @@
 use beryllium::*;
 
 fn main() -> Result<(), String> {
-  let sdl = unsafe { init()? };
+  let sdl = init()?;
 
   const FREQUENCY: i32 = 48000;
   const TWO_PI: f32 = core::f32::consts::PI * 2.0;

--- a/examples/blank_window.rs
+++ b/examples/blank_window.rs
@@ -8,7 +8,7 @@ use beryllium::*;
 fn main() -> Result<(), String> {
   // Safety Rules: You must only init SDL2 from the main thread, and you must
   // not double initialize it.
-  let sdl = unsafe { beryllium::init() }?;
+  let sdl = beryllium::init()?;
 
   let _window = sdl.create_window(
     "Window Demo",            // title

--- a/examples/extern_crate_gl.rs
+++ b/examples/extern_crate_gl.rs
@@ -7,7 +7,7 @@ use gl;
 
 fn main() -> Result<(), String> {
   // Init SDL2
-  let sdl = unsafe { beryllium::init() }?;
+  let sdl = beryllium::init()?;
 
   // Make a window (include the flag for OpenGL support!)
   let window = sdl.create_window(

--- a/examples/extern_crate_glium.rs
+++ b/examples/extern_crate_glium.rs
@@ -21,7 +21,7 @@ use std::rc::Rc;
 
 fn main() -> Result<(), String> {
   // Init SDL2
-  let sdl = unsafe { beryllium::init() }?;
+  let sdl = beryllium::init()?;
 
   // Make a window (include the flag for OpenGL support!)
   let window = sdl.create_window(

--- a/examples/fullscreen_cycle.rs
+++ b/examples/fullscreen_cycle.rs
@@ -7,7 +7,7 @@
 use beryllium::*;
 
 fn main() -> Result<(), String> {
-  let sdl = unsafe { beryllium::init()? };
+  let sdl = beryllium::init()?;
 
   let window = sdl.create_window(
     "Surface Demo",           // title

--- a/examples/joystick_check.rs
+++ b/examples/joystick_check.rs
@@ -1,7 +1,7 @@
 use beryllium::*;
 
 fn main() -> Result<(), String> {
-  let sdl = unsafe { init()? };
+  let sdl = init()?;
 
   let joystick_count = sdl.number_of_joysticks()?;
   assert!(joystick_count >= 0);

--- a/examples/simple_message_box.rs
+++ b/examples/simple_message_box.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), String> {
   }
 
   // This is the same as the `window` example
-  let sdl = unsafe { beryllium::init() }?;
+  let sdl = beryllium::init()?;
   let window = sdl.create_window(
     "Simple Message Box Window",             // title
     WINDOW_POSITION_CENTERED,                // x

--- a/examples/surface_editing.rs
+++ b/examples/surface_editing.rs
@@ -8,7 +8,7 @@
 use beryllium::*;
 
 fn main() -> Result<(), String> {
-  let sdl = unsafe { beryllium::init()? };
+  let sdl = beryllium::init()?;
 
   let window = sdl.create_window(
     "Surface Demo",           // title


### PR DESCRIPTION
Only tested on macos, but in principal if someone managed to run it on iOS, the same restriction would exist, so the check is there to maintain safety.