### PR TITLE
New window flags and window function

### DIFF
--- a/examples/window_size.rs
+++ b/examples/window_size.rs
@@ -1,0 +1,53 @@
+use beryllium::*;
+
+fn main() {
+  let sdl = SDL::init(InitFlags::Everything).expect("couldn't init SDL");
+  let _win = sdl
+    .create_gl_window(
+      "Basic Window",
+      WindowPosition::default(),
+      800,
+      600,
+      WindowFlags::Shown | WindowFlags::Resizable,
+    )
+    .expect("couldn't open a window");
+
+  _win.set_maximum_size(900, 900);
+  _win.set_minimum_size(100, 100);
+
+  loop {
+    match sdl.poll_events().and_then(Result::ok) {
+      // Quit event
+      Some(Event::Quit(QuitEvent { .. })) => break,
+      // Keyboard event
+      Some(Event::Keyboard(KeyboardEvent {
+        key: KeyInfo { keycode, .. },
+        is_pressed,
+        ..
+      })) => {
+        // If the key is pressed
+        if is_pressed {
+          // If the key is SPACE, set the window size to (1000, 1000)
+          if keycode == Keycode::SPACE {
+            _win.set_window_size(1000, 1000);
+          }
+          // If the key is RETURN, set the window set to (800, 600)
+          if keycode == Keycode::RETURN {
+            _win.set_window_size(800, 600)
+          }
+          // If the key is F11, toggle the fullscreen
+          if keycode == Keycode::F11 {
+            _win.set_fullscreen(!_win.is_fullscreen());
+          }
+        }
+      }
+      Some(Event::Window(WindowEvent { event, .. })) => match event {
+        WindowEventEnum::Resized { w, h } => {
+          println!("w: {}, h: {}", w, h);
+        }
+        _ => (),
+      },
+      _ => continue,
+    }
+  }
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -100,6 +100,17 @@ impl WindowFlags {
   pub const Vulkan: WindowFlags =
     WindowFlags(fermium::SDL_WINDOW_VULKAN as u32);
 
+  /// Window run in fullscreen mode
+  pub const Fullscreen: WindowFlags = WindowFlags(fermium::SDL_WINDOW_FULLSCREEN as u32);
+
+  /// Window run in fullscreen mode at the current desktop resolution
+  pub const FullscreenDesktop: WindowFlags = WindowFlags(fermium::SDL_WINDOW_FULLSCREEN_DESKTOP as u32);
+
+  /// Window is resizable
+  pub const Resizable: WindowFlags = WindowFlags(fermium::SDL_WINDOW_RESIZABLE as u32);
+
+  /// Window as no border
+  pub const Borderless: WindowFlags = WindowFlags(fermium::SDL_WINDOW_BORDERLESS as u32);
   // TODO: more flags later.
 }
 impl core::ops::BitOr for WindowFlags {

--- a/src/window/gl_window.rs
+++ b/src/window/gl_window.rs
@@ -150,12 +150,18 @@ impl GlWindow {
     }
   }
   /// Use this to set the fullscreen state of the window
-  pub fn set_fullscreen(&self, fullscreen: bool) {
-    unsafe {
+  pub fn set_fullscreen(&self, fullscreen: bool) -> Result<(), String> {
+    let ret = unsafe {
       fermium::SDL_SetWindowFullscreen(
         self.win.win,
         if fullscreen { WindowFlags::FullscreenDesktop.0 } else { 0 },
-      );
+      )
+    };
+
+    if ret >= 0 {
+      Ok(())
+    } else {
+      Err(self.init_token.get_error());
     }
   }
 }

--- a/src/window/gl_window.rs
+++ b/src/window/gl_window.rs
@@ -115,6 +115,49 @@ impl GlWindow {
       Err(self.init_token.get_error())
     }
   }
+
+  /// Use this to set the window size
+  pub fn set_window_size(&self, w: i32, h: i32) {
+    unsafe {
+      fermium::SDL_SetWindowSize(self.win.win, w, h);
+    }
+  }
+
+  /// Use this to set the window minimum allowed size
+  pub fn set_minimum_size(&self, w: i32, h: i32) {
+    unsafe {
+      fermium::SDL_SetWindowMinimumSize(self.win.win, w, h);
+    }
+  }
+
+  /// Use this to set the window maximum allowed size
+  pub fn set_maximum_size(&self, w: i32, h: i32) {
+    unsafe {
+      fermium::SDL_SetWindowMaximumSize(self.win.win, w, h);
+    }
+  }
+
+  /// Use this to get the fullscreen state of the window
+  ///
+  /// * `true`: the window is in fullscreen mode
+  /// * `false`: the window is in windowed mode
+  pub fn is_fullscreen(&self) -> bool {
+    unsafe {
+      let is_fullscreen: bool = (fermium::SDL_GetWindowFlags(self.win.win)
+        & WindowFlags::FullscreenDesktop.0)
+        > 0;
+      is_fullscreen
+    }
+  }
+  /// Use this to set the fullscreen state of the window
+  pub fn set_fullscreen(&self, fullscreen: bool) {
+    unsafe {
+      fermium::SDL_SetWindowFullscreen(
+        self.win.win,
+        if fullscreen { WindowFlags::FullscreenDesktop.0 } else { 0 },
+      );
+    }
+  }
 }
 
 /// The various attributes that you can request a specific value for.

--- a/src/window/gl_window.rs
+++ b/src/window/gl_window.rs
@@ -161,7 +161,7 @@ impl GlWindow {
     if ret >= 0 {
       Ok(())
     } else {
-      Err(self.init_token.get_error());
+      Err(self.init_token.get_error())
     }
   }
 }


### PR DESCRIPTION
Those changes are made after having asked about a missing feature in this issue: #110 

- Added theses flags: `Fullscreen`, `FullscreenDesktop`, `Resizable` and `Borderless`
- Added window size setter
- Added window functions for maximum and minimum window size
- Added window fullscreen setter and getter
- Created an example file with different window sizes and modes manipulation