### PR TITLE
Bump fermium to 20022.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,7 @@ pollster = "0.2"
 default-target = "x86_64-pc-windows-msvc"
 # building the docs is a "check only" style operation.
 features = ["cargo_check"]
+
+[[example]]
+name = "wgpu_demo"
+required-features = ["use-raw-window-handle"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ std = []
 use-raw-window-handle = ["raw-window-handle", "fermium/raw-window-handle"]
 
 [dependencies]
-fermium = { version = "20016.1.1", default-features = false }
+fermium = { version = "20022.0.0", default-features = false }
 zstring = "0.1.1"
 tinyvec = "1"
 bytemuck = "1"

--- a/examples/gl_demo.rs
+++ b/examples/gl_demo.rs
@@ -26,7 +26,7 @@ fn main() -> SdlResult<()> {
   let gl_win = sdl.create_gl_window(
     zstr!("GL Demo Window"),
     None,
-    (8000000, 6000000),
+    (800, 600),
     WindowFlags::ALLOW_HIGHDPI,
   )?;
   gl_win.set_swap_interval(1)?;


### PR DESCRIPTION
This bumps the fermium version so that a newer SDL verion is used. I was running into [compilation issues on wayland](https://github.com/libsdl-org/SDL/pull/5092) with the current master version.